### PR TITLE
translate: Stub in a translation framework

### DIFF
--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -147,6 +147,9 @@ inside of the container.
 **--rootfs**=ROOTFSPATH
   Path to the rootfs
 
+**--runtime**=COMMAND
+  Set the runtime command, which is used for state JSON queries in translations like **--translate=fromContainer**.
+
 **--seccomp-arch**=ARCH
   Specifies Additional architectures permitted to be used for system calls.
   By default if you turn on seccomp, only the host architecture will be allowed.
@@ -187,6 +190,10 @@ inside of the container.
     This command mounts a `tmpfs` at `/tmp` within the container.  The supported mount options are the same as the Linux default `mount` flags. If you do not specify any options, the systems uses the following options:
     `rw,noexec,nosuid,nodev,size=65536k`.
 
+**--translate**=TRANSLATION
+  Apply various higher-level spec translations.  Available
+  translations are listed in the *Translations* section.
+
 **--uid**=UID
   Sets the UID used within the container.
 
@@ -202,6 +209,18 @@ inside of the container.
   Use a UTS namespace.  If *PATH* is set, join that namespace.  If it
   is unset, create a new namespace.  The special *PATH* `host` removes
   any existing UTS namespace from the configuration.
+
+## Translations
+
+**fromContainer**
+The base OCI spec requires a namespace path in
+  `linux.namespaces[].path` to join a namespace.  However, looking up
+  that path in `/proc` can be tedious.  With a target container ID in
+  `linux.namespaces[].fromContainer`, the **fromContainer**
+  translation will query the runtime (set with **--runtime**) for the
+  state JSON, extract the container PID from that JSON, find the
+  appropriate namespace path for that PID in `/proc`, and insert that
+  path in the translated configuration as `linux.namespaces[].path`.
 
 # EXAMPLES
 

--- a/translate/from_container.go
+++ b/translate/from_container.go
@@ -1,0 +1,95 @@
+package translate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/codegangsta/cli"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func FromContainer(data interface{}, context *cli.Context) (translated interface{}, err error) {
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("data is not a map[string]interface{}: %s", data)
+	}
+
+	linuxInterface, ok := dataMap["linux"]
+	if !ok {
+		return data, nil
+	}
+
+	linux, ok := linuxInterface.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("data.linux is not a map[string]interface{}: %s", linuxInterface)
+	}
+
+	namespacesInterface, ok := linux["namespaces"]
+	if !ok {
+		return data, nil
+	}
+
+	namespaces, ok := namespacesInterface.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("data.linux.namespaces is not an array: %s", namespacesInterface)
+	}
+
+	for index, namespaceInterface := range namespaces {
+		namespace, ok := namespaceInterface.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("data.linux.namespaces[%d] is not a map[string]interface{}: %s", index, namespaceInterface)
+		}
+		err := namespaceFromContainer(&namespace, index, context)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return data, nil
+}
+
+func namespaceFromContainer(namespace *map[string]interface{}, index int, context *cli.Context) (err error) {
+	fromContainerInterface, ok := (*namespace)["fromContainer"]
+	if ok {
+		fromContainer, ok := fromContainerInterface.(string)
+		if !ok {
+			return fmt.Errorf("data.linux.namespaces[%d].fromContainer is not a string: %s", index, fromContainerInterface)
+		}
+		delete(*namespace, "fromContainer")
+		runtime := context.String("runtime")
+		if (len(runtime) == 0) {
+			return fmt.Errorf("translating fromContainer requires a non-empty --runtime")
+		}
+		command := exec.Command(runtime, "state", fromContainer)
+		var out bytes.Buffer
+		command.Stdout = &out
+		err := command.Run()
+		if err != nil {
+			return err
+		}
+		var state rspec.State
+		err = json.Unmarshal(out.Bytes(), &state)
+		if err != nil {
+			return err
+		}
+		namespaceTypeInterface, ok := (*namespace)["type"]
+		if !ok {
+			return fmt.Errorf("data.linux.namespaces[%d].type is missing: %s", index, fromContainerInterface)
+		}
+		namespaceType, ok := namespaceTypeInterface.(string)
+		if !ok {
+			return fmt.Errorf("data.linux.namespaces[%d].type is not a string: %s", index, namespaceTypeInterface)
+		}
+		switch namespaceType {
+		case "network": namespaceType = "net"
+		case "mount": namespaceType = "mnt"
+		}
+		proc := "/proc"  // FIXME: lookup in /proc/self/mounts, check right namespace
+		path := filepath.Join(proc, fmt.Sprint(state.Pid), "ns", namespaceType)
+		(*namespace)["path"] = path
+	}
+	return nil
+}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -1,0 +1,20 @@
+/*
+Package translate handles translation between configuration
+specifications.
+
+For example, it allows you to generate OCI-compliant config.json from
+a higher-level configuration language.
+*/
+package translate
+
+import (
+	"github.com/codegangsta/cli"
+)
+
+// Translate maps JSON from one specification to another.
+type Translate func(data interface{}, context *cli.Context) (translated interface{}, err error)
+
+// Translators is a map from translator names to Translate functions.
+var Translators = map[string]Translate{
+	"fromContainer": FromContainer,
+}


### PR DESCRIPTION
Add tooling to translate higher-level configs into the basic OCI config.  On IRC, @julz floated a [`linux.namespaces[].fromContainer`](http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2016-04-27.log.html#t2016-04-27T20:32:09) as a higher-level version of
`linux.namespaces[].path` for emulating exec (opencontainers/runtime-spec#391).  That makes sense to me, with a [UI like](http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2016-04-28.log.html#t2016-04-28T16:09:51):

```
$ ocitools generate --template=high-level-config.json --translate=fromContainer --runtime=runc
```

This commit still needs:
- The state JSON lookup and path logic from  opencontainers/runtime-spec#391.
- A way to convert the `interface{}` to an `rspec.Spec` (the current FIXME raises: `FATA[0000] translated template has an invalid schema`).

I'm comfortable working through the former, but would appreciate pointers on the latter from anyone who is more Go-literate than I.

More generally, I'm curious to know what folks think of this approach.  I'd rather make those before grinding through the implementation details ;).
