### PR TITLE
generate: Adjust to Spec.Linux being a pointer

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -196,6 +196,16 @@ func (g *Generator) Spec() *rspec.Spec {
 func (g *Generator) Save(w io.Writer, exportOpts ExportOptions) (err error) {
 	var data []byte
 
+	if g.spec.Linux != nil {
+		buf, err := json.Marshal(g.spec.Linux)
+		if err != nil {
+			return err
+		}
+		if string(buf) == "{}" {
+			g.spec.Linux = nil
+		}
+	}
+
 	if exportOpts.Seccomp {
 		data, err = json.MarshalIndent(g.spec.Linux.Seccomp, "", "\t")
 	} else {


### PR DESCRIPTION
Catch up with the in-flight opencontainers/runtime-spec@6323157 (specs-go/config: Make Linux and Solaris omitempty (again), 2016-06-17, opencontainers/runtime-spec#502).

The “does the marshaled JSON look like '{}'?” check is a pretty cheap trick, but it was the easiest way I could think of for “is there anything useful in here?”.  An alternative approach that conditionally added an `&rspec.Linux{}` only if needed seemed too tedious.

This should not land before opencontainers/runtime-spec#502, and it may not even be worth reviewing until then.  But I'd worked up the changes while testing the runtime-spec PR, so I thought I might as well push them in case other folks wanted to see how I'd tested it.
