### PR TITLE
test_runtime.sh: Add a user namespace

### DIFF
--- a/test_runtime.sh
+++ b/test_runtime.sh
@@ -78,7 +78,7 @@ tar -xf  rootfs.tar.gz -C ${TESTDIR}
 cp runtimetest ${TESTDIR}
 
 pushd $TESTDIR > /dev/null
-ocitools generate "${TEST_ARGS[@]}" --rootfs '.'
+ocitools generate "${TEST_ARGS[@]}" --rootfs '.' --user '' --uidmappings "$(id -u):0:1" --gidmappings "$(id -g):0:1"
 popd > /dev/null
 
 TESTCMD="${RUNTIME} start $(uuidgen)"


### PR DESCRIPTION
You shouldn't need to be root to test a runtime.  The `id` calls use the
[POSIX command](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/id.html) to find the current user's user and group IDs.

Builds on #113, so review that first.
