### PR TITLE
man: Shift examples from the README to man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,11 @@ ocitools is a collection of tools for working with the [OCI runtime specificatio
 [`ocitools generate`][generate.1] generates [configuration JSON][config.json] for an [OCI bundle][bundle].
 [OCI-compatible runtimes][runtime-spec] like [runC][] expect to read the configuration from `config.json`.
 
-```sh
-$ ocitools generate --output config.json
-$ cat config.json
-{
-        "ociVersion": "0.5.0",
-        …
-}
-```
-
 ## Validating an OCI bundle
 
 [`ocitools validate`][validate.1] validates an OCI bundle.
 The error message will be printed if the OCI bundle failed the validation procedure.
 
-```sh
-$ ocitools generate
-$ ocitools validate
-INFO[0000] Bundle validation succeeded.
-```
 
 ## Testing OCI runtimes
 

--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -226,6 +226,16 @@ inside of the container.
 
 # EXAMPLES
 
+## Generate a default configuration
+
+With choices that the ocitools developers think are sane.
+
+    $ ocitools generate
+    {
+            "ociVersion": "0.5.0",
+            …
+    }
+
 ## Generating container in read-only mode
 
 During container image development, containers often need to write to the image

--- a/man/ocitools-generate.1.md
+++ b/man/ocitools-generate.1.md
@@ -237,14 +237,14 @@ This protects the containers image from modification. Read only containers may
 still need to write temporary data.  The best way to handle this is to mount
 tmpfs directories on /generate and /tmp.
 
-    # ocitools generate --read-only --tmpfs /generate --tmpfs /tmp --tmpfs /run  --rootfs /var/lib/containers/fedora /bin/bash
+    $ ocitools generate --read-only --tmpfs /generate --tmpfs /tmp --tmpfs /run  --rootfs /var/lib/containers/fedora /bin/bash
 
 ## Exposing log messages from the container to the host's log
 
 If you want messages that are logged in your container to show up in the host's
 syslog/journal then you should bind mount the /dev/log directory as follows.
 
-    # ocitools generate --bind /dev/log:/dev/log  --rootfs /var/lib/containers/fedora /bin/bash
+    $ ocitools generate --bind /dev/log:/dev/log  --rootfs /var/lib/containers/fedora /bin/bash
 
 From inside the container you can test this by sending a message to the log.
 
@@ -264,13 +264,13 @@ To mount a host directory as a container volume, specify the absolute path to
 the directory and the absolute path for the container directory separated by a
 colon:
 
-    # ocitools generate --bind /var/db:/data1  --rootfs /var/lib/containers/fedora --args bash
+    $ ocitools generate --bind /var/db:/data1  --rootfs /var/lib/containers/fedora --args bash
 
 ## Using SELinux
 
 You can use SELinux to add security to the container.  You must specify the process label to run the init process inside of the container using the --selinux-label.
 
-    # ocitools generate --bind /var/db:/data1  --selinux-label system_u:system_r:svirt_lxc_net_t:s0:c1,c2 --mount-label system_u:object_r:svirt_sandbox_file_t:s0:c1,c2 --rootfs /var/lib/containers/fedora --args bash
+    $ ocitools generate --bind /var/db:/data1  --selinux-label system_u:system_r:svirt_lxc_net_t:s0:c1,c2 --mount-label system_u:object_r:svirt_sandbox_file_t:s0:c1,c2 --rootfs /var/lib/containers/fedora --args bash
 
 Not in the above example we used a type of svirt_lxc_net_t and an MCS Label of s0:c1,c2.  If you want to guarantee separation between containers, you need to make sure that each container gets launched with a different MCS Label pair.
 

--- a/man/ocitools-validate.1.md
+++ b/man/ocitools-validate.1.md
@@ -28,6 +28,23 @@ Validate an OCI bundle
   launching this container"), but will fail with it ("this host is not capable
   of launching this container").
 
+# EXAMPLES
+
+Generate a basic configuration:
+
+    $ ocitools generate --output config.json
+    $ mkdir rootfs
+
+Validate it for specification compliance:
+
+    $ ocitools validate
+    Bundle validation succeeded.
+
+Check whether it will run on your current host:
+
+    $ ocitools validate --host-specific
+    Bundle validation succeeded.
+
 # SEE ALSO
 **ocitools**(1)
 


### PR DESCRIPTION
If the examples are worth documenting, they're worth putting in the man
pages where users who install (but don't develop) ocitools can find them.

Also update the validation example to catch up with recent changes, and add
a --host-specific example to advertize that feature (since folks skimming
the man page quickly might expect the bare 'ocitools validate' to be
host-specific).

Also change `#` → `$` in the generate man page to show where you're
likely to need elevated permissions (you don't for `generate` calls).
