### PR TITLE
Respect the host platform

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -36,9 +36,14 @@ type ExportOptions struct {
 	Seccomp bool // seccomp toggles if only seccomp should be exported
 }
 
-// New creates a spec Generator with the default spec.
-func New() Generator {
-	spec := rspec.Spec{
+// New creates a spec Generator with the default spec for the target
+// OS.
+func New(os string) (generator Generator, err error) {
+	if os != "linux" && os != "solaris" {
+		return generator, fmt.Errorf("no defaults configured for %s", os)
+	}
+
+	config := rspec.Spec{
 		Version: rspec.Version,
 		Root: &rspec.Root{
 			Path:     "rootfs",
@@ -46,107 +51,113 @@ func New() Generator {
 		},
 		Process: &rspec.Process{
 			Terminal: false,
-			User:     rspec.User{},
 			Args: []string{
 				"sh",
 			},
-			Env: []string{
-				"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-				"TERM=xterm",
-			},
-			Cwd: "/",
-			Capabilities: &rspec.LinuxCapabilities{
-				Bounding: []string{
-					"CAP_CHOWN",
-					"CAP_DAC_OVERRIDE",
-					"CAP_FSETID",
-					"CAP_FOWNER",
-					"CAP_MKNOD",
-					"CAP_NET_RAW",
-					"CAP_SETGID",
-					"CAP_SETUID",
-					"CAP_SETFCAP",
-					"CAP_SETPCAP",
-					"CAP_NET_BIND_SERVICE",
-					"CAP_SYS_CHROOT",
-					"CAP_KILL",
-					"CAP_AUDIT_WRITE",
-				},
-				Permitted: []string{
-					"CAP_CHOWN",
-					"CAP_DAC_OVERRIDE",
-					"CAP_FSETID",
-					"CAP_FOWNER",
-					"CAP_MKNOD",
-					"CAP_NET_RAW",
-					"CAP_SETGID",
-					"CAP_SETUID",
-					"CAP_SETFCAP",
-					"CAP_SETPCAP",
-					"CAP_NET_BIND_SERVICE",
-					"CAP_SYS_CHROOT",
-					"CAP_KILL",
-					"CAP_AUDIT_WRITE",
-				},
-				Inheritable: []string{
-					"CAP_CHOWN",
-					"CAP_DAC_OVERRIDE",
-					"CAP_FSETID",
-					"CAP_FOWNER",
-					"CAP_MKNOD",
-					"CAP_NET_RAW",
-					"CAP_SETGID",
-					"CAP_SETUID",
-					"CAP_SETFCAP",
-					"CAP_SETPCAP",
-					"CAP_NET_BIND_SERVICE",
-					"CAP_SYS_CHROOT",
-					"CAP_KILL",
-					"CAP_AUDIT_WRITE",
-				},
-				Effective: []string{
-					"CAP_CHOWN",
-					"CAP_DAC_OVERRIDE",
-					"CAP_FSETID",
-					"CAP_FOWNER",
-					"CAP_MKNOD",
-					"CAP_NET_RAW",
-					"CAP_SETGID",
-					"CAP_SETUID",
-					"CAP_SETFCAP",
-					"CAP_SETPCAP",
-					"CAP_NET_BIND_SERVICE",
-					"CAP_SYS_CHROOT",
-					"CAP_KILL",
-					"CAP_AUDIT_WRITE",
-				},
-				Ambient: []string{
-					"CAP_CHOWN",
-					"CAP_DAC_OVERRIDE",
-					"CAP_FSETID",
-					"CAP_FOWNER",
-					"CAP_MKNOD",
-					"CAP_NET_RAW",
-					"CAP_SETGID",
-					"CAP_SETUID",
-					"CAP_SETFCAP",
-					"CAP_SETPCAP",
-					"CAP_NET_BIND_SERVICE",
-					"CAP_SYS_CHROOT",
-					"CAP_KILL",
-					"CAP_AUDIT_WRITE",
-				},
-			},
-			Rlimits: []rspec.POSIXRlimit{
-				{
-					Type: "RLIMIT_NOFILE",
-					Hard: uint64(1024),
-					Soft: uint64(1024),
-				},
-			},
 		},
 		Hostname: "mrsdalloway",
-		Mounts: []rspec.Mount{
+	}
+
+	if os == "linux" || os == "solaris" {
+		config.Process.User = rspec.User{}
+		config.Process.Env = []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm",
+		}
+		config.Process.Cwd = "/"
+		config.Process.Rlimits = []rspec.POSIXRlimit{
+			{
+				Type: "RLIMIT_NOFILE",
+				Hard: uint64(1024),
+				Soft: uint64(1024),
+			},
+		}
+	}
+
+	if os == "linux" {
+		config.Process.Capabilities = &rspec.LinuxCapabilities{
+			Bounding: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Permitted: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Inheritable: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Effective: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+			Ambient: []string{
+				"CAP_CHOWN",
+				"CAP_DAC_OVERRIDE",
+				"CAP_FSETID",
+				"CAP_FOWNER",
+				"CAP_MKNOD",
+				"CAP_NET_RAW",
+				"CAP_SETGID",
+				"CAP_SETUID",
+				"CAP_SETFCAP",
+				"CAP_SETPCAP",
+				"CAP_NET_BIND_SERVICE",
+				"CAP_SYS_CHROOT",
+				"CAP_KILL",
+				"CAP_AUDIT_WRITE",
+			},
+		}
+		config.Mounts = []rspec.Mount{
 			{
 				Destination: "/proc",
 				Type:        "proc",
@@ -183,8 +194,8 @@ func New() Generator {
 				Source:      "sysfs",
 				Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 			},
-		},
-		Linux: &rspec.Linux{
+		}
+		config.Linux = &rspec.Linux{
 			Resources: &rspec.LinuxResources{
 				Devices: []rspec.LinuxDeviceCgroup{
 					{
@@ -210,13 +221,11 @@ func New() Generator {
 					Type: "mount",
 				},
 			},
-			Devices: []rspec.LinuxDevice{},
-		},
+			Seccomp: seccomp.DefaultProfile(&config),
+		}
 	}
-	spec.Linux.Seccomp = seccomp.DefaultProfile(&spec)
-	return Generator{
-		spec: &spec,
-	}
+
+	return Generator{spec: &config}, nil
 }
 
 // NewFromSpec creates a spec Generator from a given spec.

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -356,6 +356,9 @@ read the configuration from `config.json`.
   Remove all mounts inside the container. The default is *false*.
   When specified with --mount-add, this option will be parsed first.
 
+**--os**=OS
+  Operating system used within the container.
+
 **--output**=PATH
   Instead of writing the configuration JSON to stdout, write it to a
   file at *PATH* (overwriting the existing content if a file already

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -577,6 +577,11 @@ func (v *Validator) CheckPlatform() (errs error) {
 		return
 	}
 
+	if v.HostSpecific && v.platform != runtime.GOOS {
+		errs = multierror.Append(errs, fmt.Errorf("platform %q differs from the host %q, skipping host-specific checks", v.platform, runtime.GOOS))
+		v.HostSpecific = false
+	}
+
 	if v.platform == "windows" {
 		if v.spec.Windows == nil {
 			errs = multierror.Append(errs,

--- a/validation/create.go
+++ b/validation/create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 
 	"github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
@@ -16,7 +17,10 @@ func main() {
 	t := tap.New()
 	t.Header(0)
 
-	g := generate.New()
+	g, err := generate.New(runtime.GOOS)
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetRootPath(".")
 	g.SetProcessArgs([]string{"ls"})
 
@@ -49,7 +53,7 @@ func main() {
 
 	for _, c := range cases {
 		r.SetID(c.id)
-		err := r.Create()
+		err = r.Create()
 		t.Ok((err == nil) == c.errExpected, c.err.(*specerror.Error).Err.Err.Error())
 		diagnostic := map[string]string{
 			"reference": c.err.(*specerror.Error).Err.Reference,

--- a/validation/default.go
+++ b/validation/default.go
@@ -5,8 +5,11 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
-	err := util.RuntimeInsideValidate(g, nil)
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/delete.go
+++ b/validation/delete.go
@@ -22,9 +22,15 @@ func main() {
 	}
 	defer os.RemoveAll(bundleDir)
 
-	stoppedConfig := util.GetDefaultGenerator()
+	stoppedConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	stoppedConfig.SetProcessArgs([]string{"true"})
-	runningConfig := util.GetDefaultGenerator()
+	runningConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	runningConfig.SetProcessArgs([]string{"sleep", "30"})
 	containerID := uuid.NewV4().String()
 	testRuntime, _ := util.NewRuntime(util.RuntimeCommand, bundleDir)
@@ -67,7 +73,7 @@ func main() {
 		if c.effectCheck {
 			// waiting for the error of State, just in case the delete operation takes time
 			util.WaitingForStatus(testRuntime, util.LifecycleActionNone, time.Second*10, time.Second*1)
-			_, err := testRuntime.State()
+			_, err = testRuntime.State()
 			// err == nil means the 'delete' operation does NOT take effect
 			util.SpecErrorOK(t, err == nil, specerror.NewError(specerror.DeleteNonStopHaveNoEffect, fmt.Errorf("attempting to `delete` a container that is not `stopped` MUST have no effect on the container"), rspecs.Version), err)
 		}

--- a/validation/hooks.go
+++ b/validation/hooks.go
@@ -23,10 +23,13 @@ func main() {
 		Actions: util.LifecycleActionCreate | util.LifecycleActionStart | util.LifecycleActionDelete,
 		PreCreate: func(r *util.Runtime) error {
 			r.SetID(uuid.NewV4().String())
-			g := util.GetDefaultGenerator()
+			g, err := util.GetDefaultGenerator()
+			if err != nil {
+				util.Fatal(err)
+			}
 			output = filepath.Join(r.BundleDir, g.Spec().Root.Path, "output")
 			shPath := filepath.Join(r.BundleDir, g.Spec().Root.Path, "/bin/sh")
-			err := g.AddPreStartHook(rspec.Hook{
+			err = g.AddPreStartHook(rspec.Hook{
 				Path: shPath,
 				Args: []string{
 					"sh", "-c", fmt.Sprintf("echo 'pre-start1 called' >> %s", output),
@@ -92,7 +95,7 @@ func main() {
 	err := util.RuntimeLifecycleValidate(config)
 	outputData, _ := ioutil.ReadFile(output)
 	if err == nil && string(outputData) != "pre-start1 called\npre-start2 called\npost-start1\npost-start2\npost-stop1\npost-stop2\n" {
-		err := specerror.NewError(specerror.PosixHooksCalledInOrder, fmt.Errorf("Hooks MUST be called in the listed order"), rspec.Version)
+		err = specerror.NewError(specerror.PosixHooksCalledInOrder, fmt.Errorf("Hooks MUST be called in the listed order"), rspec.Version)
 		diagnostic := map[string]string{
 			"error": err.Error(),
 		}

--- a/validation/hooks_stdin.go
+++ b/validation/hooks_stdin.go
@@ -60,7 +60,10 @@ func main() {
 
 	annotationKey := "org.opencontainers.runtime-tools"
 	annotationValue := "hook stdin test"
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	outputDir := filepath.Join(bundleDir, g.Spec().Root.Path)
 	timeout := 1
 	g.AddAnnotation(annotationKey, annotationValue)
@@ -117,7 +120,7 @@ func main() {
 		Annotations: map[string]string{annotationKey: annotationValue},
 	}
 	for _, file := range []string{"prestart", "poststart", "poststop"} {
-		err := stdinStateCheck(outputDir, file, expectedState)
+		err = stdinStateCheck(outputDir, file, expectedState)
 		util.SpecErrorOK(t, err == nil, specerror.NewError(specerror.PosixHooksStateToStdin, fmt.Errorf("the state of the container MUST be passed to %q hook over stdin", file), rspecs.Version), err)
 	}
 

--- a/validation/hostname.go
+++ b/validation/hostname.go
@@ -5,9 +5,12 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetHostname("hostname-specific")
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/kill.go
+++ b/validation/kill.go
@@ -22,9 +22,15 @@ func main() {
 	}
 	defer os.RemoveAll(bundleDir)
 
-	stoppedConfig := util.GetDefaultGenerator()
+	stoppedConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	stoppedConfig.SetProcessArgs([]string{"true"})
-	runningConfig := util.GetDefaultGenerator()
+	runningConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	runningConfig.SetProcessArgs([]string{"sleep", "30"})
 	containerID := uuid.NewV4().String()
 
@@ -62,12 +68,12 @@ func main() {
 				// the 'runningConfig' testcase sleeps 30 seconds, so 10 seconds are enough for this case
 				util.WaitingForStatus(*r, util.LifecycleStatusCreated|util.LifecycleStatusStopped, time.Second*10, time.Second*1)
 				// KILL MUST be supported and KILL cannot be trapped
-				err := r.Kill("KILL")
+				err = r.Kill("KILL")
 				util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
 				return err
 			},
 		}
-		err := util.RuntimeLifecycleValidate(config)
+		err = util.RuntimeLifecycleValidate(config)
 		util.SpecErrorOK(t, (err == nil) == c.errExpected, c.err, err)
 	}
 

--- a/validation/linux_cgroups_blkio.go
+++ b/validation/linux_cgroups_blkio.go
@@ -10,7 +10,10 @@ func main() {
 	var leafWeight uint16 = 300
 	var major, minor int64 = 8, 0
 	var rate uint64 = 102400
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesBlockIOWeight(weight)
 	g.SetLinuxResourcesBlockIOLeafWeight(leafWeight)
@@ -20,7 +23,7 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -13,14 +13,17 @@ func main() {
 	var period uint64 = 100000
 	var quota int64 = 50000
 	var cpus, mems string = "0-1", "0"
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesCPUShares(shares)
 	g.SetLinuxResourcesCPUQuota(quota)
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err

--- a/validation/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb.go
@@ -11,10 +11,13 @@ import (
 func main() {
 	page := "1GB"
 	var limit uint64 = 52985 * 1024 * 1024 * 1024 // multiple of hugepage size
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err

--- a/validation/linux_cgroups_memory.go
+++ b/validation/linux_cgroups_memory.go
@@ -8,7 +8,10 @@ import (
 func main() {
 	var limit int64 = 50593792
 	var swappiness uint64 = 50
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesMemoryLimit(limit)
 	g.SetLinuxResourcesMemoryReservation(limit)
@@ -17,7 +20,7 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_network.go
+++ b/validation/linux_cgroups_network.go
@@ -8,11 +8,14 @@ import (
 func main() {
 	var id, prio uint32 = 255, 10
 	ifName := "lo"
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
 	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_pids.go
+++ b/validation/linux_cgroups_pids.go
@@ -7,10 +7,13 @@ import (
 
 func main() {
 	var limit int64 = 1000
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_blkio.go
+++ b/validation/linux_cgroups_relative_blkio.go
@@ -10,7 +10,10 @@ func main() {
 	var leafWeight uint16 = 300
 	var major, minor int64 = 8, 0
 	var rate uint64 = 102400
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesBlockIOWeight(weight)
 	g.SetLinuxResourcesBlockIOLeafWeight(leafWeight)
@@ -20,8 +23,7 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
-
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_cpus.go
+++ b/validation/linux_cgroups_relative_cpus.go
@@ -12,14 +12,17 @@ func main() {
 	var period uint64 = 100000
 	var quota int64 = 50000
 	var cpus, mems string = "0-1", "0"
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesCPUShares(shares)
 	g.SetLinuxResourcesCPUQuota(quota)
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		t := tap.New()
 		t.Header(0)
 

--- a/validation/linux_cgroups_relative_hugetlb.go
+++ b/validation/linux_cgroups_relative_hugetlb.go
@@ -10,10 +10,13 @@ import (
 func main() {
 	page := "1GB"
 	var limit uint64 = 56892210544640
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		t := tap.New()
 		t.Header(0)
 

--- a/validation/linux_cgroups_relative_memory.go
+++ b/validation/linux_cgroups_relative_memory.go
@@ -8,7 +8,10 @@ import (
 func main() {
 	var limit int64 = 50593792
 	var swappiness uint64 = 50
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesMemoryLimit(limit)
 	g.SetLinuxResourcesMemoryReservation(limit)
@@ -17,7 +20,7 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_network.go
+++ b/validation/linux_cgroups_relative_network.go
@@ -8,11 +8,14 @@ import (
 func main() {
 	var id, prio uint32 = 255, 10
 	ifName := "lo"
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
 	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_pids.go
+++ b/validation/linux_cgroups_relative_pids.go
@@ -7,10 +7,13 @@ import (
 
 func main() {
 	var limit int64 = 1000
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_devices.go
+++ b/validation/linux_devices.go
@@ -8,7 +8,10 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 
 	// add char device
 	cdev := rspecs.LinuxDevice{}
@@ -48,7 +51,7 @@ func main() {
 	pdev.FileMode = &pmode
 	g.AddDevice(pdev)
 
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_masked_paths.go
+++ b/validation/linux_masked_paths.go
@@ -9,12 +9,15 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddLinuxMaskedPaths("/masked-dir")
 	g.AddLinuxMaskedPaths("/masked-file")
-	err := util.RuntimeInsideValidate(g, func(path string) error {
+	err = util.RuntimeInsideValidate(g, func(path string) error {
 		testDir := filepath.Join(path, "masked-dir")
-		err := os.MkdirAll(testDir, 0777)
+		err = os.MkdirAll(testDir, 0777)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_readonly_paths.go
+++ b/validation/linux_readonly_paths.go
@@ -9,12 +9,15 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddLinuxReadonlyPaths("/readonly-dir")
 	g.AddLinuxReadonlyPaths("/readonly-file")
-	err := util.RuntimeInsideValidate(g, func(path string) error {
+	err = util.RuntimeInsideValidate(g, func(path string) error {
 		testDir := filepath.Join(path, "readonly-dir")
-		err := os.MkdirAll(testDir, 0777)
+		err = os.MkdirAll(testDir, 0777)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_rootfs_propagation_shared.go
+++ b/validation/linux_rootfs_propagation_shared.go
@@ -5,10 +5,13 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetupPrivileged(true)
 	g.SetLinuxRootPropagation("shared")
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_rootfs_propagation_unbindable.go
+++ b/validation/linux_rootfs_propagation_unbindable.go
@@ -5,10 +5,13 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetupPrivileged(true)
 	g.SetLinuxRootPropagation("unbindable")
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_seccomp.go
+++ b/validation/linux_seccomp.go
@@ -6,14 +6,17 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	syscallArgs := seccomp.SyscallOpts{
 		Action:  "errno",
 		Syscall: "getcwd",
 	}
 	g.SetDefaultSeccompAction("allow")
 	g.SetSyscallAction(syscallArgs)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_sysctl.go
+++ b/validation/linux_sysctl.go
@@ -5,9 +5,12 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddLinuxSysctl("net.ipv4.ip_forward", "1")
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_uid_mappings.go
+++ b/validation/linux_uid_mappings.go
@@ -5,11 +5,14 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddOrReplaceLinuxNamespace("user", "")
 	g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(2000))
 	g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(3000))
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/misc_props.go
+++ b/validation/misc_props.go
@@ -40,7 +40,10 @@ func main() {
 	}
 
 	containerID := uuid.NewV4().String()
-	basicConfig := util.GetDefaultGenerator()
+	basicConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	basicConfig.SetProcessArgs([]string{"true"})
 	annotationConfig := basicConfig
 	annotationConfig.AddAnnotation(fmt.Sprintf("org.%s", containerID), "")
@@ -71,7 +74,7 @@ func main() {
 				return nil
 			},
 		}
-		err := util.RuntimeLifecycleValidate(config)
+		err = util.RuntimeLifecycleValidate(config)
 		util.SpecErrorOK(t, (err == nil) == c.errExpected, c.err, err)
 	}
 

--- a/validation/mounts.go
+++ b/validation/mounts.go
@@ -6,7 +6,10 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	mount := rspec.Mount{
 		Destination: "/tmp",
 		Type:        "tmpfs",
@@ -19,7 +22,7 @@ func main() {
 		},
 	}
 	g.AddMount(mount)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/pidfile.go
+++ b/validation/pidfile.go
@@ -24,7 +24,10 @@ func main() {
 	defer os.RemoveAll(tempDir)
 	tempPidFile := filepath.Join(tempDir, "pidfile")
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetProcessArgs([]string{"true"})
 	config := util.LifecycleConfig{
 		Config:  g,

--- a/validation/poststart.go
+++ b/validation/poststart.go
@@ -25,9 +25,12 @@ func main() {
 		Actions: util.LifecycleActionCreate | util.LifecycleActionStart | util.LifecycleActionDelete,
 		PreCreate: func(r *util.Runtime) error {
 			r.SetID(uuid.NewV4().String())
-			g := util.GetDefaultGenerator()
+			g, err := util.GetDefaultGenerator()
+			if err != nil {
+				util.Fatal(err)
+			}
 			output = filepath.Join(r.BundleDir, g.Spec().Root.Path, "output")
-			err := g.AddPostStartHook(rspec.Hook{
+			err = g.AddPostStartHook(rspec.Hook{
 				Path: filepath.Join(r.BundleDir, g.Spec().Root.Path, "/bin/sh"),
 				Args: []string{
 					"sh", "-c", fmt.Sprintf("echo 'post-start called' >> %s", output),

--- a/validation/poststart_fail.go
+++ b/validation/poststart_fail.go
@@ -24,7 +24,10 @@ func main() {
 	}
 	defer os.RemoveAll(bundleDir)
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	output := filepath.Join(bundleDir, g.Spec().Root.Path, "output")
 	poststart := rspec.Hook{
 		Path: filepath.Join(bundleDir, g.Spec().Root.Path, "/bin/false"),
@@ -59,7 +62,7 @@ func main() {
 	// if runErr is not nil, it means the runtime generates an error
 	// if outputData is not equal to the expected content, it means there is something wrong with the remaining hooks and lifecycle
 	if runErr != nil || string(outputData) != "post-start called\n" {
-		err := specerror.NewError(specerror.PoststartHookFailGenWarn, fmt.Errorf("if any poststart hook fails, the runtime MUST log a warning, but the remaining hooks and lifecycle continue as if the hook had succeeded"), rspec.Version)
+		err = specerror.NewError(specerror.PoststartHookFailGenWarn, fmt.Errorf("if any poststart hook fails, the runtime MUST log a warning, but the remaining hooks and lifecycle continue as if the hook had succeeded"), rspec.Version)
 		diagnostic := map[string]string{
 			"error": err.Error(),
 		}

--- a/validation/poststop.go
+++ b/validation/poststop.go
@@ -26,9 +26,12 @@ func main() {
 		Actions: util.LifecycleActionCreate | util.LifecycleActionStart | util.LifecycleActionDelete,
 		PreCreate: func(r *util.Runtime) error {
 			r.SetID(uuid.NewV4().String())
-			g := util.GetDefaultGenerator()
+			g, err := util.GetDefaultGenerator()
+			if err != nil {
+				util.Fatal(err)
+			}
 			output = filepath.Join(r.BundleDir, g.Spec().Root.Path, "output")
-			err := g.AddPostStopHook(rspec.Hook{
+			err = g.AddPostStopHook(rspec.Hook{
 				Path: filepath.Join(r.BundleDir, g.Spec().Root.Path, "/bin/sh"),
 				Args: []string{
 					"sh", "-c", fmt.Sprintf("echo 'post-stop called' >> %s", output),

--- a/validation/poststop_fail.go
+++ b/validation/poststop_fail.go
@@ -24,7 +24,10 @@ func main() {
 	}
 	defer os.RemoveAll(bundleDir)
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	output := filepath.Join(bundleDir, g.Spec().Root.Path, "output")
 	poststop := rspec.Hook{
 		Path: filepath.Join(bundleDir, g.Spec().Root.Path, "/bin/false"),
@@ -59,7 +62,7 @@ func main() {
 	// if runErr is not nil, it means the runtime generates an error
 	// if outputData is not equal to the expected content, it means there is something wrong with the remaining hooks and lifecycle
 	if runErr != nil || string(outputData) != "post-stop called\n" {
-		err := specerror.NewError(specerror.PoststopHookFailGenWarn, fmt.Errorf("if any poststop hook fails, the runtime MUST log a warning, but the remaining hooks and lifecycle continue as if the hook had succeeded"), rspec.Version)
+		err = specerror.NewError(specerror.PoststopHookFailGenWarn, fmt.Errorf("if any poststop hook fails, the runtime MUST log a warning, but the remaining hooks and lifecycle continue as if the hook had succeeded"), rspec.Version)
 		diagnostic := map[string]string{
 			"error": err.Error(),
 		}

--- a/validation/prestart.go
+++ b/validation/prestart.go
@@ -24,9 +24,12 @@ func main() {
 		Actions: util.LifecycleActionCreate | util.LifecycleActionStart | util.LifecycleActionDelete,
 		PreCreate: func(r *util.Runtime) error {
 			r.SetID(uuid.NewV4().String())
-			g := util.GetDefaultGenerator()
+			g, err := util.GetDefaultGenerator()
+			if err != nil {
+				util.Fatal(err)
+			}
 			output = filepath.Join(r.BundleDir, g.Spec().Root.Path, "output")
-			err := g.AddPreStartHook(rspec.Hook{
+			err = g.AddPreStartHook(rspec.Hook{
 				Path: filepath.Join(r.BundleDir, g.Spec().Root.Path, "/bin/sh"),
 				Args: []string{
 					"sh", "-c", fmt.Sprintf("echo 'pre-start called' >> %s", output),

--- a/validation/prestart_fail.go
+++ b/validation/prestart_fail.go
@@ -22,7 +22,10 @@ func main() {
 	}
 	defer os.RemoveAll(bundleDir)
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	prestart := rspec.Hook{
 		Path: filepath.Join(bundleDir, g.Spec().Root.Path, "/bin/false"),
 		Args: []string{"false"},
@@ -57,7 +60,7 @@ func main() {
 	// if outputErr is nil, it means the runtime calls the Process anyway
 	// if stateErr is nil, it means it does not continue lifecycle at step 9
 	if runErr == nil || outputErr == nil || stateErr == nil {
-		err := specerror.NewError(specerror.PrestartHookFailGenError, fmt.Errorf("if any prestart hook fails, the runtime MUST generate an error, stop the container, and continue the lifecycle at step 9"), rspec.Version)
+		err = specerror.NewError(specerror.PrestartHookFailGenError, fmt.Errorf("if any prestart hook fails, the runtime MUST generate an error, stop the container, and continue the lifecycle at step 9"), rspec.Version)
 		diagnostic := map[string]string{
 			"error": err.Error(),
 		}

--- a/validation/process.go
+++ b/validation/process.go
@@ -8,12 +8,15 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetProcessCwd("/test")
 	g.AddProcessEnv("testa", "valuea")
 	g.AddProcessEnv("testb", "123")
 
-	err := util.RuntimeInsideValidate(g, func(path string) error {
+	err = util.RuntimeInsideValidate(g, func(path string) error {
 		pathName := filepath.Join(path, "test")
 		return os.MkdirAll(pathName, 0700)
 	})

--- a/validation/process_capabilities.go
+++ b/validation/process_capabilities.go
@@ -13,9 +13,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetupPrivileged(true)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/process_capabilities_fail.go
+++ b/validation/process_capabilities_fail.go
@@ -16,9 +16,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddProcessCapabilityBounding("CAP_TEST")
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err == nil {
 		util.Fatal(specerror.NewError(specerror.LinuxProcCapError, fmt.Errorf("Any value which cannot be mapped to a relevant kernel interface MUST cause an error"), rspecs.Version))
 	}

--- a/validation/process_oom_score_adj.go
+++ b/validation/process_oom_score_adj.go
@@ -5,9 +5,12 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetProcessOOMScoreAdj(500)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/process_rlimits.go
+++ b/validation/process_rlimits.go
@@ -13,9 +13,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddProcessRlimits("RLIMIT_NOFILE", 1024, 1024)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/process_rlimits_fail.go
+++ b/validation/process_rlimits_fail.go
@@ -16,9 +16,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.AddProcessRlimits("RLIMIT_TEST", 1024, 1024)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err == nil {
 		util.Fatal(specerror.NewError(specerror.PosixProcRlimitsTypeGenError, fmt.Errorf("The runtime MUST generate an error for any values which cannot be mapped to a relevant kernel interface"), rspecs.Version))
 	}

--- a/validation/process_user.go
+++ b/validation/process_user.go
@@ -7,7 +7,10 @@ import (
 )
 
 func main() {
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 
 	switch runtime.GOOS {
 	case "linux", "solaris":
@@ -19,7 +22,7 @@ func main() {
 	default:
 	}
 
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/root_readonly_true.go
+++ b/validation/root_readonly_true.go
@@ -13,9 +13,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetRootReadonly(true)
-	err := util.RuntimeInsideValidate(g, nil)
+	err = util.RuntimeInsideValidate(g, nil)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/start.go
+++ b/validation/start.go
@@ -30,7 +30,10 @@ func main() {
 	if err != nil {
 		util.Fatal(err)
 	}
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetProcessArgs([]string{"sh", "-c", fmt.Sprintf("echo 'process called' >> %s", "/output")})
 	err = r.SetConfig(g)
 	if err != nil {
@@ -62,7 +65,7 @@ func main() {
 	if err != nil {
 		util.SpecErrorOK(t, false, specerror.NewError(specerror.StartProcImplement, fmt.Errorf("`start` operation MUST run the user-specified program as specified by `process`"), rspecs.Version), err)
 	} else {
-		err := util.WaitingForStatus(r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
+		err = util.WaitingForStatus(r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
 		if err != nil {
 			util.Fatal(err)
 		}

--- a/validation/state.go
+++ b/validation/state.go
@@ -15,7 +15,10 @@ func main() {
 	t := tap.New()
 	t.Header(0)
 
-	g := util.GetDefaultGenerator()
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	g.SetProcessArgs([]string{"true"})
 	containerID := uuid.NewV4().String()
 
@@ -39,11 +42,11 @@ func main() {
 				return nil
 			},
 			PostCreate: func(r *util.Runtime) error {
-				_, err := r.State()
+				_, err = r.State()
 				return err
 			},
 		}
-		err := util.RuntimeLifecycleValidate(config)
+		err = util.RuntimeLifecycleValidate(config)
 		// DefaultStateJSONPattern might returns
 		if e, ok := err.(*specerror.Error); ok {
 			diagnostic := map[string]string{

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -141,11 +141,14 @@ func PrepareBundle() (string, error) {
 }
 
 // GetDefaultGenerator creates a default configuration generator.
-func GetDefaultGenerator() *generate.Generator {
-	g := generate.New()
+func GetDefaultGenerator() (*generate.Generator, error) {
+	g, err := generate.New(runtime.GOOS)
+	if err != nil {
+		return nil, err
+	}
 	g.SetRootPath(".")
 	g.SetProcessArgs([]string{"/runtimetest", "--path=/"})
-	return &g
+	return &g, err
 }
 
 // WaitingForStatus waits an expected runtime status, return error if


### PR DESCRIPTION
Details in the commit messages, but the net effect is to respect
runtime.GOOS and runtime.GOARCH when --host-specific is set (for both
generate and validate).  Also add an argument to generate.New to set
the target OS (falling back to runtime.GOOS).
