### PR TITLE
[1.0.0.rc1] validation: add check for namespace path

### DIFF
--- a/cmd/oci-runtime-tool/validate.go
+++ b/cmd/oci-runtime-tool/validate.go
@@ -333,6 +333,13 @@ func checkLinux(spec rspec.Spec, rootfs string, hostCheck bool) (msgs []string) 
 			} else if spec.Linux.Namespaces[index].Type == rspec.UserNamespace {
 				userExists = true
 			}
+		} else if hostCheck {
+			_, err := os.Stat(spec.Linux.Namespaces[index].Path)
+			if os.IsNotExist(err) {
+				msgs = append(msgs, fmt.Sprintf("Path of %v not exist", spec.Linux.Namespaces[index].Type))
+			} else if err != nil {
+				msgs = append(msgs, fmt.Sprintf("%v is invalid: %s", spec.Linux.Namespaces[index].Type, err.Error()))
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Backported to v1.0.0.rc1 from c8b8c73 #192 (cherry-pick applied
cleanly).

Signed-off-by: W. Trevor King <wking@tremily.us>