### PR TITLE
[1.0.0.rc1] runtimetest: remove unnecessary else

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -281,10 +281,9 @@ func validateDefaultDevices(spec *rspec.Spec) error {
 				return fmt.Errorf("device node %v not found", device)
 			}
 			return err
-		} else {
-			if fi.Mode()&os.ModeDevice != os.ModeDevice {
-				return fmt.Errorf("file %v is not a device as expected", device)
-			}
+		}
+		if fi.Mode()&os.ModeDevice != os.ModeDevice {
+			return fmt.Errorf("file %v is not a device as expected", device)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Backported to v1.0.0.rc1 from 609040b4 #208 (cherry-pick applied cleanly).

Signed-off-by: W. Trevor King <wking@tremily.us>

This builds on #215, so you can either:

a. Merge #215 and then consider this one.
b. Merge this one which will automatically close #215.