### PR TITLE
sanitize: Add a config-sanitization command

### DIFF
--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -27,6 +27,7 @@ func main() {
 	app.Commands = []cli.Command{
 		generateCommand,
 		bundleValidateCommand,
+		sanitizeCommand,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/cmd/oci-runtime-tool/sanitize.go
+++ b/cmd/oci-runtime-tool/sanitize.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/sanitize"
+	"github.com/urfave/cli"
+)
+
+var sanitizeFlags = []cli.Flag{
+	cli.StringFlag{Name: "output", Usage: "output file (defaults to stdout)"},
+}
+
+var sanitizeCommand = cli.Command{
+	Name:   "sanitize",
+	Usage:  "sanitize an OCI runtime configuration file",
+	Flags:  sanitizeFlags,
+	Before: before,
+	Action: func(context *cli.Context) (err error) {
+		var reader io.ReadCloser
+		if context.NArg() == 0 {
+			reader = os.Stdin
+		} else if context.NArg() == 1 {
+			reader, err = os.Open(context.Args().First())
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
+		} else {
+			return fmt.Errorf("too many arguments (%d > 1)", context.NArg())
+		}
+
+		var config rspec.Spec
+		err = json.NewDecoder(reader).Decode(&config)
+		if err != nil {
+			return err
+		}
+
+		err = reader.Close()
+		if err != nil {
+			return err
+		}
+
+		err = sanitize.Sanitize(&config)
+		if err != nil {
+			return err
+		}
+
+		var writer io.WriteCloser
+		if context.IsSet("output") {
+			writer, err = os.OpenFile(context.String("output"), os.O_WRONLY | os.O_TRUNC, 0)
+			if err != nil {
+				return err
+			}
+			defer writer.Close()
+		} else {
+			writer = os.Stdout
+		}
+
+		encoder := json.NewEncoder(writer)
+		return encoder.Encode(&config)
+	},
+}

--- a/sanitize/sanitize.go
+++ b/sanitize/sanitize.go
@@ -1,0 +1,76 @@
+// Package sanitize removes dangerous and questionably-portable properties from container configurations.
+package sanitize
+
+import (
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Santize removes dangerous and questionably-portable properties from container configurations.
+func Sanitize(config *rspec.Spec) (err error) {
+	config.Process.Terminal = false
+	//config.Process.ConsoleSize = nil  // needs runtime-spec#581
+	config.Process.User.AdditionalGids = []uint32{}
+	config.Process.Capabilities = []string{}
+	config.Process.Rlimits = []rspec.Rlimit{}
+	config.Process.NoNewPrivileges = false
+	config.Process.ApparmorProfile = ""
+	config.Process.SelinuxLabel = ""
+	config.Root = rspec.Root{
+		Path: "rootfs",
+	}
+	config.Hostname = ""
+	//config.Hooks = nil  // needs runtime-spec#427
+
+	for i, _ := range config.Mounts {
+		config.Mounts[i].Source = ""
+	}
+
+	if config.Linux != nil {
+		config.Linux.UIDMappings = []rspec.IDMapping{}
+		config.Linux.GIDMappings = []rspec.IDMapping{}
+		config.Linux.Sysctl = map[string]string{}
+		config.Linux.CgroupsPath = nil
+		config.Linux.Namespaces = []rspec.Namespace{}
+		config.Linux.Devices = []rspec.Device{}
+		config.Linux.Seccomp = nil
+		config.Linux.RootfsPropagation = ""
+		config.Linux.MaskedPaths = []string{}
+		config.Linux.MaskedPaths = []string{}
+		config.Linux.MountLabel = ""
+
+		if config.Linux.Resources != nil {
+			config.Linux.Resources.Devices = []rspec.DeviceCgroup{}
+			config.Linux.Resources.DisableOOMKiller = nil
+			config.Linux.Resources.OOMScoreAdj= nil
+			config.Linux.Resources.Pids = nil
+			config.Linux.Resources.BlockIO = nil
+			config.Linux.Resources.HugepageLimits = []rspec.HugepageLimit{}
+			config.Linux.Resources.Network = nil
+
+			if config.Linux.Resources.Memory != nil {
+				config.Linux.Resources.Memory.Kernel = nil
+				config.Linux.Resources.Memory.KernelTCP = nil
+				config.Linux.Resources.Memory.Swappiness = nil
+			}
+
+			if config.Linux.Resources.CPU != nil {
+				config.Linux.Resources.CPU.Quota = nil
+				config.Linux.Resources.CPU.Period = nil
+				config.Linux.Resources.CPU.RealtimeRuntime = nil
+				config.Linux.Resources.CPU.Period = nil
+				config.Linux.Resources.CPU.Cpus = nil
+				config.Linux.Resources.CPU.Mems = nil
+			}
+		}
+	}
+
+	if config.Solaris != nil {
+		config.Solaris.Milestone = ""
+		config.Solaris.LimitPriv = ""
+		config.Solaris.MaxShmMemory = ""
+		config.Solaris.Anet = []rspec.Anet{}
+		config.Solaris.CappedCPU = nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
Based on image-spec, which [currently exposes](https://github.com/opencontainers/image-spec/blob/v0.5.0/serialization.md#container-runconfig-field-descriptions):
- `User` (user and group by ID or name).
  Represented in runtime-spec by `process.user.*`, although I'm clearing
  `additionalGids` for now because the old formats gave no way to
  represent that.
- `Memory` (limit).
  Represented in runtime-spec by `linux.resources.memory.limit` and
  `solaris.cappedMemory.physical`.
- `MemorySwap` (memory + swap limit).
  Represented in runtime-spec by `linux.resources.memory.swap` and
  `solaris.cappedMemory.physical` + `solaris.cappedMemory.swap`.
- `CpuShares` (relative weight vs. other containers).
  Represented in runtime-spec by `linux.resources.cpu.shares`.  Solaris
  has an `ncpus` property, but no shares analog.
- `ExposedPorts` (a set of port/protocol entries).
  This is not covered by runtime-spec, but image-spec was [planning on
  stuffing it into annotations](https://github.com/opencontainers/image-spec/issues/87#issuecomment-224185157).
- `Env` (array of environment variables).
  Represented in runtime-spec by `process.env`.
- `Entrypoint` (array of positional arguments).
  Represented in runtime-spec by `process.cmd`.
- `Cmd` (array of positional arguments).
  Represented in runtime-spec by `process.cmd`.
- `Volumes` (set of directories which should have data volumes mounted
  on them).
  Represented in runtime-spec by `mounts`, although `Volumes` doesn't
  include `source` locations.
- `WorkingDir` (initial working directory of container process).
  Represented in runtime-spec by `process.cwd`.

`Entrypoint` and `Cmd` are slightly different and have a few [different](https://docs.docker.com/engine/reference/builder/#entrypoint) [forms](https://docs.docker.com/engine/reference/builder/#cmd) each.  Both are represented in the runtime-spec config by `process.args`.

This commit sets all other config settings to their default values, and it clears `mounts[].source` to mimic the `Volumes` information.  image-spec currently [sets up `source`-less bind-mounts when translating `Volumes`](https://github.com/opencontainers/image-spec/blob/v0.5.0/image/config.go#L127-L136).

With the sanitization command, _any_ runtime configuration can be sanitized to be just as safe and limited as the current image-spec config.  That allows us to replace the [current](https://github.com/opencontainers/image-spec/blob/v0.5.0/cmd/oci-image-tool/man/oci-image-tool-create-runtime-bundle.1.md):
1. [Unpack](https://github.com/opencontainers/image-spec/blob/v0.5.0/cmd/oci-image-tool/man/oci-image-tool-unpack.1.md) the rootfs.
2. Fetch the config, translate it to runtime-spec's format, and save it as `config.json`.

with:
1. [Unpack](https://github.com/opencontainers/image-spec/blob/v0.5.0/cmd/oci-image-tool/man/oci-image-tool-unpack.1.md) the bundle.
2. Sanitize `config.json` if the file exists in the unpacked bundle.

That gets image-spec out of the business of cherry-picking portions of runtime-spec's format that are portable and/or extending it to support things like `ExposedPorts`.  Miss-matches made some images impossible (there was no way to say “containers launched from this image will need a terminal” without using annotations) and the translation was sometimes awkward (opencontainers/image-spec#87 suggested putting `Entrypoint` in annotations, and the translation [only supported integer IDs for users and groups](https://github.com/opencontainers/image-spec/blob/v0.5.0/image/config.go#L92-L100) while [claiming support for names as well](https://github.com/opencontainers/image-spec/blame/v0.5.0/serialization.md#L181)).

I'm sure there's room for improving the set of properties that are being sanitized, but I'd rather punt on that level of discussion until there's a consensus about whether this approach has legs at all ;).
