### PR TITLE
use go > 1.5 since golint drop support for 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5.3
+  - 1.6
 
 sudo: false
 


### PR DESCRIPTION
go 1.5.3 fails to run golint in 'travis' file.

Find the reason for this:
https://github.com/golang/lint/commit/a428635c58fe96360e83667e2e1a8343fc292bf0

Signed-off-by: liang chenye <liangchenye@huawei.com>