### PR TITLE
[1.0.0.rc1] use go > 1.5 since golint drop support for 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5.3
+  - 1.6
 
 sudo: false
 


### PR DESCRIPTION
Signed-off-by: liang chenye <liangchenye@huawei.com>

Backported to v1.0.0.rc1 from f9096d89 #230 (cherry-pick applied cleanly).

Signed-off-by: W. Trevor King <wking@tremily.us>