### PR TITLE
[1.0.0.rc1] small fix: fomart variable as CamelCase

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -309,10 +309,10 @@ func validateLinuxDevices(spec *rspec.Spec) error {
 			}
 		}
 		if device.FileMode != nil {
-			expected_perm := *device.FileMode & os.ModePerm
-			actual_perm := fi.Mode() & os.ModePerm
-			if expected_perm != actual_perm {
-				return fmt.Errorf("%v filemode expected is %v, actual is %v", device.Path, expected_perm, actual_perm)
+			expectedPerm := *device.FileMode & os.ModePerm
+			actualPerm := fi.Mode() & os.ModePerm
+			if expectedPerm != actualPerm {
+				return fmt.Errorf("%v filemode expected is %v, actual is %v", device.Path, expectedPerm, actualPerm)
 			}
 		}
 		if device.UID != nil {


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

Backported to v1.0.0.rc1 from baf6c3bb #236 (cherry-pick applied cleanly).

Signed-off-by: W. Trevor King <wking@tremily.us>