### PR TITLE
[Master] generate/generate: Fix "specifed" -> "specified" typo

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -158,7 +158,7 @@ func NewFromSpec(spec *rspec.Spec) Generator {
 	}
 }
 
-// NewFromFile loads the template specifed in a file into a spec Generator.
+// NewFromFile loads the template specified in a file into a spec Generator.
 func NewFromFile(path string) (Generator, error) {
 	cf, err := os.Open(path)
 	if err != nil {
@@ -650,7 +650,7 @@ func (g *Generator) AddBindMount(source, dest, options string) {
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
 }
 
-// SetupPrivileged sets up the priviledge-related fields inside g.spec.
+// SetupPrivileged sets up the privilege-related fields inside g.spec.
 func (g *Generator) SetupPrivileged(privileged bool) {
 	if privileged {
 		// Add all capabilities in privileged mode.


### PR DESCRIPTION
And a "priviledge" -> "privilege" typo.  Both turned up by Misspell
[1](https://github.com/client9/misspell) and reported by Go Report Card [2](https://goreportcard.com/report/github.com/opencontainers/runtime-tools).

Backported to master from #251 

Signed-off-by: W. Trevor King wking@tremily.us
Signed-off-by: Ma Shimiao mashimiao.fnst@cn.fujitsu.com
