### PR TITLE
generate: make AddBindMount() options a slice

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -17,7 +17,7 @@ var generateFlags = []cli.Flag{
 	cli.StringFlag{Name: "apparmor", Usage: "specifies the the apparmor profile for the container"},
 	cli.StringFlag{Name: "arch", Value: runtime.GOARCH, Usage: "architecture the container is created for"},
 	cli.StringSliceFlag{Name: "args", Usage: "command to run in the container"},
-	cli.StringSliceFlag{Name: "bind", Usage: "bind mount directories src:dest:(rw,ro)"},
+	cli.StringSliceFlag{Name: "bind", Usage: "bind mount directories src:dest[:options...]"},
 	cli.StringSliceFlag{Name: "cap-add", Usage: "add Linux capabilities"},
 	cli.StringSliceFlag{Name: "cap-drop", Usage: "drop Linux capabilities"},
 	cli.StringFlag{Name: "cgroup", Usage: "cgroup namespace"},
@@ -491,18 +491,18 @@ func parseTmpfsMount(s string) (string, []string, error) {
 	return dest, options, err
 }
 
-func parseBindMount(s string) (string, string, string, error) {
+func parseBindMount(s string) (string, string, []string, error) {
 	var source, dest string
-	options := "ro"
+	options := []string{}
 
 	bparts := strings.SplitN(s, ":", 3)
 	switch len(bparts) {
 	case 2:
 		source, dest = bparts[0], bparts[1]
 	case 3:
-		source, dest, options = bparts[0], bparts[1], bparts[2]
+		source, dest, options = bparts[0], bparts[1], strings.Split(bparts[2], ":")
 	default:
-		return source, dest, options, fmt.Errorf("--bind should have format src:dest:[options]")
+		return source, dest, options, fmt.Errorf("--bind should have format src:dest[:options...]")
 	}
 
 	return source, dest, options, nil

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -29,15 +29,15 @@ read the configuration from `config.json`.
 
   --args "/usr/bin/httpd" --args "-D" --args "FOREGROUND"
 
-**--bind**=*[[HOST-DIR:CONTAINER-DIR][:OPTIONS]]*
+**--bind**=*[[HOST-DIR:CONTAINER-DIR][:OPTIONS...]]*
   Bind mount directories src:dest:(rw,ro) If you specify, ` --bind
   /HOST-DIR:/CONTAINER-DIR`, runc bind mounts `/HOST-DIR` in the host
-  to `/CONTAINER-DIR` in the OCI container. The `OPTIONS` are a comma
-  delimited list and can be: [rw|ro] The `HOST_DIR` and
-  `CONTAINER-DIR` must be absolute paths such as `/src/docs`.  You
-  can add `:ro` or `:rw` suffix to a volume to mount it read-only or
-  read-write mode, respectively. By default, the volumes are mounted
-  read-write.
+  to `/CONTAINER-DIR` in the OCI container. The `OPTIONS` are a colon
+  delimited list and can be any mount option support by the runtime such
+  as [rw|ro|rbind|bind|...]. The `HOST_DIR` and `CONTAINER-DIR` must be
+  absolute paths such as `/src/docs`.  You can set the `ro` or `rw`
+  options to a bind-mount to mount it read-only or read-write mode,
+  respectively. By default, bind-mounts are mounted read-write.
 
 **--cap-add**=[]
   Add Linux capabilities


### PR DESCRIPTION
This allows for the set of options to be more useful than just "rw" or
"ro". It also makes it match the AddTmpfsMount far more.

We should also probably implement `AddMount` which just simply
adds a mount.

Signed-off-by: Aleksa Sarai <asarai@suse.com>