### PR TITLE
generate: Respect --os when generating default templates

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -92,21 +92,23 @@ var generateCommand = cli.Command{
 	Before: before,
 	Action: func(context *cli.Context) error {
 		// Start from the default template.
-		specgen := generate.New()
+		specgen, err := generate.New(nil)
+		if err != nil {
+			return err
+		}
 
 		var template string
 		if context.IsSet("template") {
 			template = context.String("template")
 		}
 		if template != "" {
-			var err error
 			specgen, err = generate.NewFromFile(template)
 			if err != nil {
 				return err
 			}
 		}
 
-		err := setupSpec(&specgen, context)
+		err = setupSpec(&specgen, context)
 		if err != nil {
 			return err
 		}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -11,6 +11,7 @@ import (
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate/seccomp"
+	"github.com/Sirupsen/logrus"
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -284,15 +285,23 @@ func (g *Generator) RemoveAnnotation(key string) {
 }
 
 // SetPlatformOS sets g.spec.Process.OS.
-func (g *Generator) SetPlatformOS(os string) {
+func (g *Generator) SetPlatformOS(os string) error {
+	if g.HostSpecific && os != runtime.GOOS {
+		return fmt.Errorf("cannot set platform.os to %s on a %s host", os, runtime.GOOS)
+	}
 	g.initSpec()
 	g.spec.Platform.OS = os
+	return nil
 }
 
 // SetPlatformArch sets g.spec.Platform.Arch.
-func (g *Generator) SetPlatformArch(arch string) {
+func (g *Generator) SetPlatformArch(arch string) error {
+	if g.HostSpecific && arch != runtime.GOARCH {
+		logrus.Warnf("setting platform.arch to %s on a %s host", arch, runtime.GOARCH)
+	}
 	g.initSpec()
 	g.spec.Platform.Arch = arch
+	return nil
 }
 
 // SetProcessUID sets g.spec.Process.User.UID.

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -173,7 +173,13 @@ read the configuration from `config.json`.
   Specifies oom_score_adj for the container.
 
 **--os**=OS
-  Operating system used within the container
+  Operating system used within the container.  When no template is
+  set, the default is to use the `GOOS` ocitools was built with and to
+  default other settings based on this setting.  For example, if
+  `GOOS` is `linux`, `ocitools generate` will generate a default Linux
+  config, `ocitools generate --os=windows` will generate a default
+  Windows config, and `ocitools --host-specific generate --os=windows`
+  will exit with an error.
 
 **--output**=PATH
   Instead of writing the configuration JSON to stdout, write it to a

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -163,6 +164,16 @@ func (v *Validator) CheckPlatform() (msgs []string) {
 		}
 	}
 	msgs = append(msgs, fmt.Sprintf("Operation system %q of the bundle is not supported yet.", platform.OS))
+
+	if hostCheck {
+		if platform.OS != runtime.GOOS {
+			msgs = append(msgs, fmt.Sprintf("platform.os is %s, not %s", platform.OS, runtime.GOOS))
+		}
+		if platform.Arch != runtime.GOARCH {
+			// warning, not an error, since kernels can support multiple architectures
+			msgs = append(msgs, fmt.Sprintf("platform.arch is %s, not %s", platform.Arch, runtime.GOARCH))
+		}
+	}
 
 	return
 }


### PR DESCRIPTION
Also add `--host-specific` checks to `SetPlatformOS` and `SetPlatformArch`.  The `SetPlatformArch` check is currently just a warning (details in eda1ac7, validate: With --host-specific, compare config platform vs. runtime, 2016-08-16) but I've added an error to its API so callers will be ready when we do actually raise errors (e.g. for `--arch arm` on an amd64 box).

Also add IsSet checks to `--os` and `--arch` so we don't clobber their template values.  Before this commit on my amd64 Linux box:

    $ echo '{"platform": {"os": "windows", "arch": "386"}}' >template.json
    $ ocitools generate --template template.json | jq .platform
    {
      "os": "linux",
      "arch": "amd64"
    }

After this commit:

    $ ocitools generate --template template.json | jq .platform
    {
      "os": "windows",
      "arch": "386"
    }

This commit was previously part of #194, but I've pulled it out into its own PR because @Mashimiao [isn't sold yet][1] ;).

[1]: https://github.com/opencontainers/runtime-tools/pull/194#issuecomment-260518219