### PR TITLE
Add docker-style --env-file flag support.

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -279,6 +279,7 @@ _oci-runtime-tool_generate() {
 	      --cwd
 	      --disable-oom-kill
 	      --env
+	      --env-file
 	      --gid
 	      --gidmappings
 	      --groups
@@ -403,6 +404,11 @@ _oci-runtime-tool_generate() {
 			__oci-runtime-tool_nospace
 			return
 			;;
+		--env-file)
+		    _filedir
+			__oci-runtime-tool_nospace
+		    return
+		    ;;
 		$(__oci-runtime-tool_to_extglob "$options_with_args") )
 			return
 			;;

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -65,6 +65,13 @@ read the configuration from `config.json`.
   This option allows you to specify arbitrary environment variables
   that are available for the process that will be launched inside of
   the container.
+  
+**--env-file**=[]
+  Set environment variables from a file.
+  This option sets environment variables in the container from the
+  contents of a file formatted with key=value pairs, one per line.
+  When specified multiple times, files are loaded in order with duplicate
+  keys overwriting previous ones.
 
 **--gid**=GID
   Gid for the process inside of container


### PR DESCRIPTION
Allow generating configs with environment variables sourced from a file using the same syntax as docker.

Closes #275 