### PR TITLE
generate: fix annotations parse

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -157,8 +157,8 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("label") {
 		annotations := context.StringSlice("label")
 		for _, s := range annotations {
-			pair := strings.Split(s, "=")
-			if len(pair) != 2 {
+			pair := strings.SplitN(s, "=", 2)
+			if len(pair) != 2 || pair[0] == "" {
 				return fmt.Errorf("incorrectly specified annotation: %s", s)
 			}
 			g.AddAnnotation(pair[0], pair[1])

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -96,6 +96,7 @@ read the configuration from `config.json`.
 
 **--label**=[]
   Add annotations to the configuration e.g. key=value.
+  Currently, key containing equals sign is not supported.
 
 **--linux-cpu-shares**=CPUSHARES
   Specifies a relative share of CPU time available to the tasks in a cgroup.


### PR DESCRIPTION
It's valid for values to start with '=' .

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>