### PR TITLE
validate.go：Increase the type of checkplatform

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -142,10 +142,11 @@ func (v *Validator) CheckPlatform() (msgs []string) {
 	logrus.Debugf("check platform")
 
 	validCombins := map[string][]string{
+		"android":   {"arm"},
 		"darwin":    {"386", "amd64", "arm", "arm64"},
 		"dragonfly": {"amd64"},
 		"freebsd":   {"386", "amd64", "arm"},
-		"linux":     {"386", "amd64", "arm", "arm64", "ppc64", "ppc64le", "mips64", "mips64le"},
+		"linux":     {"386", "amd64", "arm", "arm64", "ppc64", "ppc64le", "mips64", "mips64le", "s390x"},
 		"netbsd":    {"386", "amd64", "arm"},
 		"openbsd":   {"386", "amd64", "arm"},
 		"plan9":     {"386", "amd64"},


### PR DESCRIPTION
According to [runtime-spec's platform.arch](https://golang.org/doc/install/source#environment),completion check type.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>