### PR TITLE
generate: add device option

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -26,6 +26,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "cap-drop", Usage: "drop Linux capabilities"},
 	cli.StringFlag{Name: "cgroups-path", Usage: "specify the path to the cgroups"},
 	cli.StringFlag{Name: "cwd", Value: "/", Usage: "current working directory for the process"},
+	cli.StringSliceFlag{Name: "device", Usage: "specifies a device which must be made available in the container"},
 	cli.BoolFlag{Name: "disable-oom-kill", Usage: "disable OOM Killer"},
 	cli.StringSliceFlag{Name: "env", Usage: "add environment variable e.g. key=value"},
 	cli.StringSliceFlag{Name: "env-file", Usage: "read in a file of environment variables"},
@@ -501,6 +502,15 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		g.ClearProcessRlimits()
 	}
 
+	if context.IsSet("device") {
+		devices := context.StringSlice("device")
+		for _, deviceArg := range devices {
+			err := addDevice(deviceArg, g)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	err := addSeccomp(context, g)
 	return err
 }
@@ -623,6 +633,87 @@ func parseNamespace(ns string) (string, string, error) {
 	}
 
 	return nsType, nsPath, nil
+}
+
+var deviceType = map[string]bool{
+	"b": true, // a block (buffered) special file
+	"c": true, // a character special file
+	"u": true, // a character (unbuffered) special file
+	"p": true, // a FIFO
+}
+
+// addDevice takes the raw string passed with the --device flag, parses it, and add it
+func addDevice(device string, g *generate.Generator) error {
+	dev := rspec.Device{}
+
+	// The required part and optional part are seperated by ":"
+	argsParts := strings.Split(device, ":")
+	if len(argsParts) < 4 {
+		return fmt.Errorf("Incomplete device arguments: %s", device)
+	}
+	requiredPart := argsParts[0:4]
+	optionalPart := argsParts[4:]
+
+	// The required part must contain type, major, minor, and path
+	dev.Type = requiredPart[0]
+	if !deviceType[dev.Type] {
+		return fmt.Errorf("Invalid device type: %s", dev.Type)
+	}
+
+	i, err := strconv.ParseInt(requiredPart[1], 10, 64)
+	if err != nil {
+		return err
+	}
+	dev.Major = i
+
+	i, err = strconv.ParseInt(requiredPart[2], 10, 64)
+	if err != nil {
+		return err
+	}
+	dev.Minor = i
+	dev.Path = requiredPart[3]
+
+	// The optional part include all optional property
+	for _, s := range optionalPart {
+		parts := strings.SplitN(s, "=", 2)
+
+		if len(parts) != 2 {
+			return fmt.Errorf("Incomplete device arguments: %s", s)
+		}
+
+		name, value := parts[0], parts[1]
+
+		switch name {
+		case "fileMode":
+			i, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return err
+			}
+			mode := os.FileMode(i)
+			dev.FileMode = &mode
+		case "uid":
+			i, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return err
+			}
+			uid := uint32(i)
+			dev.UID = &uid
+
+		case "gid":
+			i, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return err
+			}
+			gid := uint32(i)
+			dev.GID = &gid
+		default:
+			return fmt.Errorf("'%s' is not supported by device section", name)
+		}
+	}
+
+	g.AddDevice(dev.Path, dev.Type, dev.Major, dev.Minor, dev.FileMode, dev.UID, dev.GID)
+
+	return nil
 }
 
 func addSeccomp(context *cli.Context, g *generate.Generator) error {

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -305,6 +305,7 @@ _oci-runtime-tool_generate() {
 		--cap-drop
 		--cgroups-path
 		--cwd
+		--device
 		--env
 		--env-file
 		--gid

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -914,6 +914,22 @@ func (g *Generator) RemoveLinuxNamespace(ns string) error {
 	return nil
 }
 
+// AddDevice - add a device into g.spec.Linux.Devices
+func (g *Generator) AddDevice(path, devType string, major, minor int64, fileMode *os.FileMode, uid, gid *uint32) {
+	g.initSpecLinux()
+
+	device := rspec.Device{
+		Path:     path,
+		Type:     devType,
+		Major:    major,
+		Minor:    minor,
+		FileMode: fileMode,
+		UID:      uid,
+		GID:      gid,
+	}
+	g.spec.Linux.Devices = append(g.spec.Linux.Devices, device)
+}
+
 // strPtr returns the pointer pointing to the string s.
 func strPtr(s string) *string { return &s }
 

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -51,6 +51,16 @@ read the configuration from `config.json`.
 **--cwd**=PATH
   Current working directory for the process. The deafult is */*.
 
+**--device**=*TYPE:MAJOR:MINOR:PATH[:OPTIONS...]*
+  Add a device file in container. e.g. --device=c:10:229:/dev/fuse:fileMode=438:uid=0:gid=0
+  The *TYPE*, *MAJOR*, *MINOR*, *PATH* are required.
+    *TYPE* is the device type. The acceptable values are b (block), c (character), u (unbuffered), p (FIFO).
+    *MAJOR*/*MINOR* is the major/minor device id.
+    *PATH* is the device path.
+  The *fileMode*, *uid*, *gid* are optional.
+    *fileMode* is the file mode of the device file.
+    *uid*/*gid* is the user/group id of the device file.
+
 **--disable-oom-kill**=true|false
   Whether to disable OOM Killer for the container or not.
 


### PR DESCRIPTION
generate a device section in config.json.

Example
oci-runtime-tool generate --device c:10:229:/dev/fuse:fileMode=438:uid=0:gid=0  --device b:8:0:/dev/sda:fileMode=438:uid=0:gid=0

According to [Devices.](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#devices)
Signed-off-by: Zhai Zhaoxuan <zhaizx.fnst@cn.fujitsu.com>