### PR TITLE
fix bug for --arch and --seccomp-arch in bash completion

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -364,12 +364,12 @@ _oci-runtime-tool_generate() {
 
 	case "$prev" in
 		--seccomp-arch)
-			COMPREPLY=( $( compgen -W $( __oci-runtime-tool_complete_seccomp_arches ) -- "$cur" ) )
+		    __oci-runtime-tool_complete_seccomp_arches
 			return
 			;;
 
 		--arch)
-			COMPREPLY=( $( compgen -W $( __oci-runtime-tool_complete_arches ) -- "$cur" ) )
+		    __oci-runtime-tool_complete_arches
 			return
 			;;
 


### PR DESCRIPTION
Both `__oci-runtime-tool_complete_seccomp_arches` and `__oci-runtime-tool_complete_arches` just fill `$COMPREPLY` and output nothing.
We should not use their output to reset `$COMPREPLY` in `_oci-runtime-tool_generate`.

This patch prevent the "reset" operation, and fix the bug.