### PR TITLE
add linux-hugepage-limit option.

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -311,6 +311,7 @@ _oci-runtime-tool_generate() {
 	      --help
 	      --ipc
 	      --label
+	      --linux-hugepage-limit
 	      --linux-network-classid
 	      --linux-network-priorities
 	      --linux-pids-limit

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -562,6 +562,18 @@ func (g *Generator) SetLinuxResourcesPidsLimit(limit int64) {
 	g.spec.Linux.Resources.Pids.Limit = &limit
 }
 
+// AddHugepageLimit adds hugepage limit into g.spec.Linux.MaskedPaths.
+func (g *Generator) AddLinuxResourcesHugepageLimit(pagesize string, limit uint64) {
+	g.initSpecLinuxResources()
+
+	hugepageLimit := rspec.HugepageLimit{
+		Pagesize: &pagesize,
+		Limit:    &limit,
+	}
+
+	g.spec.Linux.Resources.HugepageLimits = append(g.spec.Linux.Resources.HugepageLimits, hugepageLimit)
+}
+
 // ClearLinuxSysctl clears g.spec.Linux.Sysctl.
 func (g *Generator) ClearLinuxSysctl() {
 	if g.spec == nil || g.spec.Linux == nil {

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -110,6 +110,11 @@ read the configuration from `config.json`.
 **--linux-cpus**=CPUS
   Sets the CPUs to use within the cpuset (default is to use any CPU available).
 
+**--linux-hugepage-limit**=*SIZE*:*LIMIT*
+  Add a hugepage limit to the configuration.
+  *SIZE* represents hugepage size.
+  *LIMIT* represents limit in bytes of hugepagesize HugeTLB usage.
+  
 **--linux-mem-kernel-limit**=MEMKERNELLIMIT
   Sets the hard limit of kernel memory in bytes.
 


### PR DESCRIPTION
add a hugepageLimits section in config.json.

Usage
oci-runtime-tool generate --linux-hugepage-limit 2MB:209715200

According to [Huge page limits](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#huge-page-limits).
