### PR TITLE
generate: add --device-access-add and --device-access-remove option

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -301,6 +301,8 @@ _oci-runtime-tool_generate() {
 	      --cgroup
 	      --cgroup-path
 	      --cwd
+	      --device-access-add
+	      --device-access-remove
 	      --disable-oom-kill
 	      --env
 	      --env-file

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -915,6 +915,39 @@ func (g *Generator) RemoveLinuxNamespace(ns string) error {
 	return nil
 }
 
+// AddLinuxResourcesDevice - add a device into g.spec.Linux.Resources.Devices
+func (g *Generator) AddLinuxResourcesDevice(allow bool, devType *string, major, minor *int64, access *string) {
+	g.initSpecLinuxResources()
+
+	device := rspec.DeviceCgroup{
+		Allow:  allow,
+		Type:   devType,
+		Access: access,
+		Major:  major,
+		Minor:  minor,
+	}
+	g.spec.Linux.Resources.Devices = append(g.spec.Linux.Resources.Devices, device)
+}
+
+// RemoveLinuxResourcesDevice - remove a device from g.spec.Linux.Resources.Devices
+func (g *Generator) RemoveLinuxResourcesDevice(allow bool, devType *string, major, minor *int64, access *string) {
+	if g.spec == nil || g.spec.Linux == nil || g.spec.Linux.Resources == nil {
+		return
+	}
+	for i, device := range g.spec.Linux.Resources.Devices {
+		if device.Allow == allow &&
+			(devType == device.Type || (devType != nil && device.Type != nil && *devType == *device.Type)) &&
+			(access == device.Access || (access != nil && device.Access != nil && *access == *device.Access)) &&
+			(major == device.Major || (major != nil && device.Major != nil && *major == *device.Major)) &&
+			(minor == device.Minor || (minor != nil && device.Minor != nil && *minor == *device.Minor)) {
+
+			g.spec.Linux.Resources.Devices = append(g.spec.Linux.Resources.Devices[:i], g.spec.Linux.Resources.Devices[i+1:]...)
+			return
+		}
+	}
+	return
+}
+
 // strPtr returns the pointer pointing to the string s.
 func strPtr(s string) *string { return &s }
 

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -57,6 +57,17 @@ read the configuration from `config.json`.
 **--cwd**=PATH
   Current working directory for the process. The deafult is */*.
 
+**--device-access-add**=allow|deny[,type=TYPE][,major=MAJOR][,minor=MINOR][,access=ACCESS]
+  Add a device control rule.
+  allow|deny: whether the entry is allowed or denied.
+  TYPE: the device type. The value could be one of 'a' (all), 'b' (block), 'c' (character).
+  MAJOR/MINOR: the major/minor id of device.
+  ACCESS: cgroup permissions for device. A composition of r (read), w (write), and m (mknod).
+
+**--device-access-remove**=allow|deny[,type=TYPE][,major=MAJOR][,minor=MINOR][,access=ACCESS]
+  Remove a device control rule.
+  The arguments is same as *--device-access-add*.
+  
 **--disable-oom-kill**=true|false
   Whether to disable OOM Killer for the container or not.
 


### PR DESCRIPTION
These options allow user to configures the device whitelist.

According to [this](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#device-whitelist)

Usage:
```
oci-runtime-tool generate \
--device-access-remove=deny,access=rwm \
--device-access-add=allow,type=c,major=10,minor=229,access=rw \
--device-access-add=allow,type=b,major=8,minor=0,access=r
```
