### PR TITLE
validate: add validation for OOMScoreAdj

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -417,6 +417,9 @@ func (v *Validator) CheckLinuxResources() (msgs []string) {
 		}
 	}
 
+	if r.OOMScoreAdj != nil && (*r.OOMScoreAdj < -1000 || *r.OOMScoreAdj > 1000) {
+		msgs = append(msgs, fmt.Sprintf("OOMScoreAdj is invalid. Acceptable values range from -1000 to +1000."))
+	}
 	return
 }
 


### PR DESCRIPTION
The acceptable values range from -1000 to +1000.

According to the description of "oom_score_adj" (https://www.kernel.org/doc/Documentation/filesystems/proc.txt)
