### PR TITLE
MAINTAINERS: Remove Alexander

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 Michael Crosby <michael@docker.com> (@crosbymichael)
-Alexander Morozov <lk4d4@docker.com> (@LK4D4)
 Vishnu Kannan <vishnuk@google.com> (@vishh)
 Mrunal Patel <mpatel@redhat.com> (@mrunalp)
 Vincent Batts <vbatts@redhat.com> (@vbatts)


### PR DESCRIPTION
On Tue, 7 Mar 2017 at 11:57-0800, @LK4D4 [wrote][1]:
> Hello, I'd like to resign from all OCI roles which were assigned to me because I don't work with containers anymore.

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/JvN8jWhS55c