### PR TITLE
bash-completion: add some architectures.

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -137,6 +137,14 @@ __oci-runtime-tool_complete_arches() {
 		386
 		amd64
 		arm
+		arm64
+		mips
+		mips64
+		mips64le
+		mipsle
+		ppc64
+		ppc64le
+		s390x
 	" -- "$cur" ) )
 }
 


### PR DESCRIPTION
According to the runtime-spec, the values which can be accept by --arch
are listed in the Go Language document for $GOARCH.

I found [the list](https://golang.org/doc/install/source#environment), and added some missed values