### PR TITLE
*: remove RHEL6 hack and loosen capability validation

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1023,7 +1023,7 @@ func (g *Generator) SetupPrivileged(privileged bool) {
 	if privileged { // Add all capabilities in privileged mode.
 		var finalCapList []string
 		for _, cap := range capability.List() {
-			if g.HostSpecific && cap > validate.LastCap() {
+			if g.HostSpecific && cap > capability.CAP_LAST_CAP {
 				continue
 			}
 			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -687,23 +687,28 @@ func (v *Validator) CheckAnnotations() (errs error) {
 	return
 }
 
-// CapValid checks whether a capability is valid
+// CapValid checks whether a capability is valid. This only really checks
+// anything with hostSpecific, otherwise we just ignore everything (because
+// capabilities are now free-form strings).
 func CapValid(c string, hostSpecific bool) error {
-	isValid := false
+	// Cannot speak to whether the capability makes sense.
+	if !hostSpecific {
+		return nil
+	}
 
+	isValid := false
 	if !strings.HasPrefix(c, "CAP_") {
 		return fmt.Errorf("capability %s must start with CAP_", c)
 	}
 	for _, cap := range capability.List() {
 		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
-			if hostSpecific && cap > LastCap() {
+			if cap > capability.CAP_LAST_CAP {
 				return fmt.Errorf("%s is not supported on the current host", c)
 			}
 			isValid = true
 			break
 		}
 	}
-
 	if !isValid {
 		return fmt.Errorf("invalid capability: %s", c)
 	}

--- a/validate/validate_linux.go
+++ b/validate/validate_linux.go
@@ -10,25 +10,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/syndtr/gocapability/capability"
-
 	multierror "github.com/hashicorp/go-multierror"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	osFilepath "github.com/opencontainers/runtime-tools/filepath"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/sirupsen/logrus"
 )
-
-// LastCap return last cap of system
-func LastCap() capability.Cap {
-	last := capability.CAP_LAST_CAP
-	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
-	if last == capability.Cap(63) {
-		last = capability.CAP_BLOCK_SUSPEND
-	}
-
-	return last
-}
 
 func deviceValid(d rspec.LinuxDevice) bool {
 	switch d.Type {

--- a/validate/validate_unsupported.go
+++ b/validate/validate_unsupported.go
@@ -2,15 +2,6 @@
 
 package validate
 
-import (
-	"github.com/syndtr/gocapability/capability"
-)
-
-// LastCap return last cap of system
-func LastCap() capability.Cap {
-	return capability.Cap(-1)
-}
-
 // CheckLinux is a noop on this platform
 func (v *Validator) CheckLinux() (errs error) {
 	return nil


### PR DESCRIPTION
The RHEL6 hack for CAP_LAST_CAP was causing us some annoyances, with the
inter-dependency of generate and validate only existing because of
CapValid (which then resulted in a bunch of build-time dependencies that
were never used by projects that vendored us).

To fix this issue, drop CapValid entirely so we don't have to touch it
anymore -- just assume that CAP_LAST_CAP works on all systems. And in
the case of validation we match new changes in the spec where
capabilities are now just plain strings (but for the HostSpecific case
we still do validation).

Fixes: 1a899a6d893e ("validate: optimize capabilites check")
Signed-off-by: Aleksa Sarai <asarai@suse.de>