### PR TITLE
validate: fix spec.Hooks nil dereference

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -200,9 +200,11 @@ func (v *Validator) CheckPlatform() (msgs []string) {
 func (v *Validator) CheckHooks() (msgs []string) {
 	logrus.Debugf("check hooks")
 
-	msgs = append(msgs, checkEventHooks("pre-start", v.spec.Hooks.Prestart, v.HostSpecific)...)
-	msgs = append(msgs, checkEventHooks("post-start", v.spec.Hooks.Poststart, v.HostSpecific)...)
-	msgs = append(msgs, checkEventHooks("post-stop", v.spec.Hooks.Poststop, v.HostSpecific)...)
+	if v.spec.Hooks != nil {
+		msgs = append(msgs, checkEventHooks("pre-start", v.spec.Hooks.Prestart, v.HostSpecific)...)
+		msgs = append(msgs, checkEventHooks("post-start", v.spec.Hooks.Poststart, v.HostSpecific)...)
+		msgs = append(msgs, checkEventHooks("post-stop", v.spec.Hooks.Poststop, v.HostSpecific)...)
+	}
 
 	return
 }


### PR DESCRIPTION
Fixes the following issue:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4ce0c9]

  goroutine 1 [running]:
  panic(0x5ad320, 0xc4200120a0)
  	/usr/lib64/go/src/runtime/panic.go:500 +0x1a1
  github.com/opencontainers/runtime-tools/validate.(*Validator).CheckHooks(0xc4200b77b8, 0xc420084d80, 0x0, 0x0)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/validate/validate.go:203 +0x89
  github.com/opencontainers/runtime-tools/validate.(*Validator).CheckAll(0xc4200b77b8, 0x26, 0x0, 0xc4200aa000)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/validate/validate.go:109 +0x582
  main.glob..func2(0xc4200a2140, 0x0, 0x20000c4200a2140)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/cmd/oci-runtime-tool/validate.go:28 +0x107
  github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.HandleAction(0x5a51a0, 0x5f7620, 0xc4200a2140, 0xc42005a300, 0x0)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/app.go:485 +0xd4
  github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.Command.Run(0x5dcbc9, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5e0f3c, 0x16, 0x0, ...)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/command.go:193 +0xb96
  github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.(*App).Run(0xc420064d00, 0xc4200601b0, 0x3, 0x3, 0x0, 0x0)
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/app.go:250 +0x812
  main.main()
  	/home/abuild/rpmbuild/BUILD/go/src/github.com/opencontainers/runtime-tools/cmd/oci-runtime-tool/main.go:32 +0x2fe
```

Signed-off-by: Aleksa Sarai <asarai@suse.de>