### PR TITLE
validate: delete the extra defaultCaps

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -40,22 +40,6 @@ var (
 		"RLIMIT_SIGPENDING",
 		"RLIMIT_STACK",
 	}
-	defaultCaps = []string{
-		"CAP_CHOWN",
-		"CAP_DAC_OVERRIDE",
-		"CAP_FSETID",
-		"CAP_FOWNER",
-		"CAP_MKNOD",
-		"CAP_NET_RAW",
-		"CAP_SETGID",
-		"CAP_SETUID",
-		"CAP_SETFCAP",
-		"CAP_SETPCAP",
-		"CAP_NET_BIND_SERVICE",
-		"CAP_SYS_CHROOT",
-		"CAP_KILL",
-		"CAP_AUDIT_WRITE",
-	}
 )
 
 // Validator represents a validator for runtime bundle


### PR DESCRIPTION
Because of the changes in #220, delete the extra `defaultCaps`.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>