### PR TITLE
runtimetest: fix readonly validation 

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -303,7 +303,7 @@ func testWriteAccess(path string) error {
 func validateRootFS(spec *rspec.Spec) error {
 	logrus.Debugf("validating root filesystem")
 	if spec.Root.Readonly {
-		err := testWriteAccess("/")
+		err := testWriteAccess(spec.Root.Path)
 		if err == nil {
 			return fmt.Errorf("Rootfs should be readonly")
 		}


### PR DESCRIPTION
According to this [spec.](https://github.com/opencontainers/runtime-spec/blame/master/config.md#L36)

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>