### PR TITLE
validate: increase os verification to checklinux

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -441,6 +441,11 @@ func (v *Validator) CheckOS() (msgs []string) {
 func (v *Validator) CheckLinux() (msgs []string) {
 	logrus.Debugf("check linux")
 
+	if v.spec.Platform.OS != "linux" {
+		logrus.Warnf("%q is not supported to check linux", v.spec.Platform.OS)
+		return
+	}
+
 	var typeList = map[rspec.LinuxNamespaceType]struct {
 		num      int
 		newExist bool


### PR DESCRIPTION
If `os` is not `linux`, then do not have to implement the next code, improve efficiency.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>