### PR TITLE
validate: add the validation of Resources.devices

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -555,6 +555,14 @@ func (v *Validator) CheckLinuxResources() (msgs []string) {
 			}
 		}
 	}
+	for index := 0; index < len(r.Devices); index++ {
+		switch r.Devices[index].Type {
+		case "a", "b", "c":
+		default:
+			msgs = append(msgs, fmt.Sprintf("type of devices %s is invalid", r.Devices[index].Type))
+		}
+
+	}
 
 	return
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -562,6 +562,15 @@ func (v *Validator) CheckLinuxResources() (msgs []string) {
 			msgs = append(msgs, fmt.Sprintf("type of devices %s is invalid", r.Devices[index].Type))
 		}
 
+		access := []byte(r.Devices[index].Access)
+		for i := 0; i < len(access); i++ {
+			switch access[i] {
+			case 'r', 'w', 'm':
+			default:
+				msgs = append(msgs, fmt.Sprintf("access %s is invalid", r.Devices[index].Access))
+				return
+			}
+		}
 	}
 
 	return


### PR DESCRIPTION
According to the following spec：

[devices.type](https://github.com/opencontainers/runtime-spec/blame/master/config-linux.md#L218)
[devices.access](https://github.com/opencontainers/runtime-spec/blame/master/config-linux.md#L222-L223)

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>