### PR TITLE
generate: Assign value to devices.type when the value is empty

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -141,6 +141,12 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	}
 
 	spec := g.Spec()
+	devices := spec.Linux.Resources.Devices
+	for index := 0; index < len(devices); index++ {
+		if devices[index].Type == "" {
+			devices[index].Type = "a"
+		}
+	}
 
 	if len(spec.Version) == 0 {
 		g.SetVersion(rspec.Version)


### PR DESCRIPTION
https://github.com/opencontainers/runtime-spec/blame/master/config-linux.md#L219

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>