### PR TITLE
generate: drop caps in every cap set

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -912,35 +912,30 @@ func (g *Generator) DropProcessCapability(c string) error {
 	for i, cap := range g.spec.Process.Capabilities.Bounding {
 		if strings.ToUpper(cap) == cp {
 			g.spec.Process.Capabilities.Bounding = append(g.spec.Process.Capabilities.Bounding[:i], g.spec.Process.Capabilities.Bounding[i+1:]...)
-			return nil
 		}
 	}
 
 	for i, cap := range g.spec.Process.Capabilities.Effective {
 		if strings.ToUpper(cap) == cp {
 			g.spec.Process.Capabilities.Effective = append(g.spec.Process.Capabilities.Effective[:i], g.spec.Process.Capabilities.Effective[i+1:]...)
-			return nil
 		}
 	}
 
 	for i, cap := range g.spec.Process.Capabilities.Inheritable {
 		if strings.ToUpper(cap) == cp {
 			g.spec.Process.Capabilities.Inheritable = append(g.spec.Process.Capabilities.Inheritable[:i], g.spec.Process.Capabilities.Inheritable[i+1:]...)
-			return nil
 		}
 	}
 
 	for i, cap := range g.spec.Process.Capabilities.Permitted {
 		if strings.ToUpper(cap) == cp {
 			g.spec.Process.Capabilities.Permitted = append(g.spec.Process.Capabilities.Permitted[:i], g.spec.Process.Capabilities.Permitted[i+1:]...)
-			return nil
 		}
 	}
 
 	for i, cap := range g.spec.Process.Capabilities.Ambient {
 		if strings.ToUpper(cap) == cp {
 			g.spec.Process.Capabilities.Ambient = append(g.spec.Process.Capabilities.Ambient[:i], g.spec.Process.Capabilities.Ambient[i+1:]...)
-			return nil
 		}
 	}
 


### PR DESCRIPTION
commit afc8d3588cbf9c5de0be4ab00d352077be78a0d3 updated the
runtime-spec version but introduced a bug when dropping capabilities.
If you drop a capability it will only be dropped in the Bounding
capabilities set while kept in the other sets.
This causes a bug when using the generated config.json in which
containers cannot be started at all.
This patch fixes the above by dropping `return nil` statements.

@mrunalp @Mashimiao PTAL asap

Signed-off-by: Antonio Murdaca <runcom@redhat.com>