### PR TITLE
validate: Alphabetize arch entries for Linux

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -158,7 +158,7 @@ func (v *Validator) CheckPlatform() (msgs []string) {
 		"darwin":    {"386", "amd64", "arm", "arm64"},
 		"dragonfly": {"amd64"},
 		"freebsd":   {"386", "amd64", "arm"},
-		"linux":     {"386", "amd64", "arm", "arm64", "mips", "mipsle", "mips64", "mips64le", "ppc64", "ppc64le", "s390x"},
+		"linux":     {"386", "amd64", "arm", "arm64", "mips", "mips64", "mips64le", "mipsle", "ppc64", "ppc64le", "s390x"},
 		"netbsd":    {"386", "amd64", "arm"},
 		"openbsd":   {"386", "amd64", "arm"},
 		"plan9":     {"386", "amd64"},


### PR DESCRIPTION
So folks adding new mips* entries don't have to agonize over where to put them ;).

Earlier discussion [here][1].

[1]: https://github.com/opencontainers/runtime-tools/pull/368#discussion_r112497741