### PR TITLE
Add commit to version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ BINDIR ?= $(DESTDIR)/usr/bin
 
 BUILDTAGS=
 RUNTIME ?= runc
+COMMIT=$(shell git rev-parse HEAD 2> /dev/null || true)
 
 all: tool runtimetest
 
 tool:
-	go build -tags "$(BUILDTAGS)" -o oci-runtime-tool ./cmd/oci-runtime-tool
+	go build -tags "$(BUILDTAGS)" -ldflags "-X main.gitCommit=${COMMIT}" -o oci-runtime-tool ./cmd/oci-runtime-tool
 
 .PHONY: runtimetest
 runtimetest:

--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -1,16 +1,25 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
+// gitCommit will be the hash that the binary was built from
+// and will be populated by the Makefile
+var gitCommit = ""
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "oci-runtime-tool"
-	app.Version = "0.0.1"
+	if gitCommit != "" {
+		app.Version = fmt.Sprintf("0.0.1, commit: %s", gitCommit)
+	} else {
+		app.Version = "0.0.1"
+	}
 	app.Usage = "OCI (Open Container Initiative) runtime tools"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{


### PR DESCRIPTION
It make user know more information about `oci-runtime-tool`.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>