### PR TITLE
validate: fix spec nil dereference

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -261,7 +261,9 @@ func (v *Validator) CheckProcess() (msgs []string) {
 		}
 	}
 
-	msgs = append(msgs, v.CheckCapabilities()...)
+	if v.spec.Process.Capabilities != nil {
+		msgs = append(msgs, v.CheckCapabilities()...)
+	}
 	msgs = append(msgs, v.CheckRlimits()...)
 
 	if v.spec.Platform.OS == "linux" {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -89,8 +89,10 @@ func (v *Validator) CheckAll() (msgs []string) {
 	msgs = append(msgs, v.CheckPlatform()...)
 	msgs = append(msgs, v.CheckProcess()...)
 	msgs = append(msgs, v.CheckOS()...)
-	msgs = append(msgs, v.CheckLinux()...)
 	msgs = append(msgs, v.CheckHooks()...)
+	if v.spec.Linux != nil {
+		msgs = append(msgs, v.CheckLinux()...)
+	}
 
 	return
 }


### PR DESCRIPTION
Solve the following questions：

> panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x4d29be]
goroutine 1 [running]:
panic(0x5ac0e0, 0xc420012100)
	/home/zhouhao/go/src/runtime/panic.go:500 +0x1a1
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckLinux(0xc42004f7c8, 0xc4200a80c0, 0x0, 0x2)
	/home/zhouhao/runtime-tools/Godeps/_workspace/src/github.com/opencontainers/runtime-tools/validate/validate.go:436 +0x41e
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckAll(0xc42004f7c8, 0x1, 0x0, 0xc4200a4000)
	/home/zhouhao/runtime-tools/Godeps/_workspace/src/github.com/opencontainers/runtime-tools/validate/validate.go:92 +0x4d2
main.glob.func2(0xc4200a2140, 0x0, 0x20000c4200a2140)
	/home/zhouhao/runtime-tools/cmd/oci-runtime-tool/validate.go:28 +0x107
github.com/urfave/cli.HandleAction(0x5a4680, 0x5f47b8, 0xc4200a2140, 0xc420070300, 0x0)
	/home/zhouhao/runtime-tools/Godeps/_workspace/src/github.com/urfave/cli/app.go:485 +0xd4
github.com/urfave/cli.Command.Run(0x5d9bfc, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5ddf9e, 0x16, 0x0, ...)
	/home/zhouhao/runtime-tools/Godeps/_workspace/src/github.com/urfave/cli/command.go:193 +0xb96
github.com/urfave/cli.(*App).Run(0xc420094340, 0xc42000c680, 0x2, 0x2, 0x0, 0x0)
	/home/zhouhao/runtime-tools/Godeps/_workspace/src/github.com/urfave/cli/app.go:250 +0x812
main.main()
	/home/zhouhao/runtime-tools/cmd/oci-runtime-tool/main.go:32 +0x2f7


Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>