### PR TITLE
use current pid instead of 1

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -446,7 +446,7 @@ func validateOOMScoreAdj(spec *rspec.Spec) error {
 	logrus.Debugf("validating oomScoreAdj")
 	if spec.Linux.Resources != nil && spec.Linux.Resources.OOMScoreAdj != nil {
 		expected := *spec.Linux.Resources.OOMScoreAdj
-		f, err := os.Open("/proc/1/oom_score_adj")
+		f, err := os.Open("/proc/self/oom_score_adj")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If we don't use pid namespace, the process's pid will not be 1

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>