### PR TITLE
runtimetest: fix mounts check

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -557,6 +557,11 @@ func validateMountsExist(spec *rspec.Spec) error {
 	}
 
 	for _, specMount := range spec.Mounts {
+		if specMount.Type == "bind" || specMount.Type == "rbind" {
+			// TODO: add bind or rbind check.
+			continue
+		}
+
 		found := false
 		for _, sysMount := range mountsMap[filepath.Clean(specMount.Destination)] {
 			if err := mountMatch(specMount, sysMount); err == nil {


### PR DESCRIPTION
Even if bind mount succeed, there will not any bind or rbind key word
in type of options of mount.
So, we can not make sure if bind mount succeed.
It'd better to skip bind mount check

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>