### PR TITLE
fix seccomp-default parse and remove problem

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -159,11 +159,11 @@ __oci-runtime-tool_complete_seccomp_arches() {
 # context of oci-runtime-tool containers.
 __oci-runtime-tool_complete_seccomp_actions() {
 	COMPREPLY=( $( compgen -W "
-		SCMP_ACT_ALLOW
-		SCMP_ACT_ERRNO
-		SCMP_ACT_KILL
-		SCMP_ACT_TRACE
-		SCMP_ACT_TRAP
+		allow
+		errno
+		kill
+		trace
+		trap
 	" -- "$cur" ) )
 }
 __oci-runtime-tool_complete_capabilities() {

--- a/generate/seccomp/parse_action.go
+++ b/generate/seccomp/parse_action.go
@@ -97,7 +97,7 @@ func ParseDefaultAction(action string, config *rspec.LinuxSeccomp) error {
 		return err
 	}
 	config.DefaultAction = defaultAction
-	err = RemoveAllMatchingRules(config, action)
+	err = RemoveAllMatchingRules(config, defaultAction)
 	if err != nil {
 		return err
 	}

--- a/generate/seccomp/parse_remove.go
+++ b/generate/seccomp/parse_remove.go
@@ -15,12 +15,7 @@ func RemoveAction(arguments string, config *rspec.LinuxSeccomp) error {
 		return fmt.Errorf("Cannot remove action from nil Seccomp pointer")
 	}
 
-	var syscallsToRemove []string
-	if strings.Contains(arguments, ",") {
-		syscallsToRemove = strings.Split(arguments, ",")
-	} else {
-		syscallsToRemove = append(syscallsToRemove, arguments)
-	}
+	syscallsToRemove := strings.Split(arguments, ",")
 
 	for counter, syscallStruct := range config.Syscalls {
 		if reflect.DeepEqual(syscallsToRemove, syscallStruct.Names) {
@@ -42,14 +37,9 @@ func RemoveAllSeccompRules(config *rspec.LinuxSeccomp) error {
 }
 
 // RemoveAllMatchingRules will remove any syscall rules that match the specified action
-func RemoveAllMatchingRules(config *rspec.LinuxSeccomp, action string) error {
+func RemoveAllMatchingRules(config *rspec.LinuxSeccomp, seccompAction rspec.LinuxSeccompAction) error {
 	if config == nil {
 		return fmt.Errorf("Cannot remove action from nil Seccomp pointer")
-	}
-
-	seccompAction, err := parseAction(action)
-	if err != nil {
-		return err
 	}
 
 	for _, syscall := range config.Syscalls {

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -193,11 +193,11 @@ read the configuration from `config.json`.
 
 **--linux-seccomp-default**=ACTION
   Specifies the the default action of Seccomp syscall restrictions and removes existing restrictions with the specified action
-  Values: KILL,ERRNO,TRACE,ALLOW
+  Values: kill, trap, errno, trace, allow
 
 **--linux-seccomp-default-force**=ACTION
   Specifies the the default action of Seccomp syscall restrictions
-  Values: KILL,ERRNO,TRACE,ALLOW
+  Values: kill, trap, errno, trace, allow
 
 **--linux-seccomp-errno**=SYSCALL
   Specifies syscalls to create seccomp rule to respond with ERRNO.


### PR DESCRIPTION
1. completion for --seccomp-default is not correct, need to fix it and manpage.
2. There is no need to call parseAction() twice, we can pass type rspec.LinuxSeccompAction directly.
3. There is no need to distinguish whether string contains ',' or not, split can handle them.