### PR TITLE
remove duplicated caps for syscalls

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -370,26 +370,25 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 	var sysCloneFlagsIndex uint
 
 	capSysAdmin := false
-	var cap string
-	var caps []string
+	caps := make(map[string]bool)
 
-	for _, cap = range rs.Process.Capabilities.Bounding {
-		caps = append(caps, cap)
+	for _, cap := range rs.Process.Capabilities.Bounding {
+		caps[cap] = true
 	}
-	for _, cap = range rs.Process.Capabilities.Effective {
-		caps = append(caps, cap)
+	for _, cap := range rs.Process.Capabilities.Effective {
+		caps[cap] = true
 	}
-	for _, cap = range rs.Process.Capabilities.Inheritable {
-		caps = append(caps, cap)
+	for _, cap := range rs.Process.Capabilities.Inheritable {
+		caps[cap] = true
 	}
-	for _, cap = range rs.Process.Capabilities.Permitted {
-		caps = append(caps, cap)
+	for _, cap := range rs.Process.Capabilities.Permitted {
+		caps[cap] = true
 	}
-	for _, cap = range rs.Process.Capabilities.Ambient {
-		caps = append(caps, cap)
+	for _, cap := range rs.Process.Capabilities.Ambient {
+		caps[cap] = true
 	}
 
-	for _, cap = range caps {
+	for cap := range caps {
 		switch cap {
 		case "CAP_DAC_READ_SEARCH":
 			syscalls = append(syscalls, []rspec.LinuxSyscall{


### PR DESCRIPTION
duplicated caps will generate duplicated syscalls.
We should avoid that.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>