### PR TITLE
generate: initialize the Hooks pointer

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -714,12 +714,15 @@ func (g *Generator) ClearPreStartHooks() {
 	if g.spec == nil {
 		return
 	}
+	if g.spec.Hooks == nil {
+		return
+	}
 	g.spec.Hooks.Prestart = []rspec.Hook{}
 }
 
 // AddPreStartHook add a prestart hook into g.spec.Hooks.Prestart.
 func (g *Generator) AddPreStartHook(path string, args []string) {
-	g.initSpec()
+	g.initSpecHooks()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, hook)
 }
@@ -729,12 +732,15 @@ func (g *Generator) ClearPostStopHooks() {
 	if g.spec == nil {
 		return
 	}
+	if g.spec.Hooks == nil {
+		return
+	}
 	g.spec.Hooks.Poststop = []rspec.Hook{}
 }
 
 // AddPostStopHook adds a poststop hook into g.spec.Hooks.Poststop.
 func (g *Generator) AddPostStopHook(path string, args []string) {
-	g.initSpec()
+	g.initSpecHooks()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, hook)
 }
@@ -744,12 +750,15 @@ func (g *Generator) ClearPostStartHooks() {
 	if g.spec == nil {
 		return
 	}
+	if g.spec.Hooks == nil {
+		return
+	}
 	g.spec.Hooks.Poststart = []rspec.Hook{}
 }
 
 // AddPostStartHook adds a poststart hook into g.spec.Hooks.Poststart.
 func (g *Generator) AddPostStartHook(path string, args []string) {
-	g.initSpec()
+	g.initSpecHooks()
 	hook := rspec.Hook{Path: path, Args: args}
 	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, hook)
 }

--- a/generate/spec.go
+++ b/generate/spec.go
@@ -17,6 +17,13 @@ func (g *Generator) initSpecAnnotations() {
 	}
 }
 
+func (g *Generator) initSpecHooks() {
+	g.initSpec()
+	if g.spec.Hooks == nil {
+		g.spec.Hooks = &rspec.Hooks{}
+	}
+}
+
 func (g *Generator) initSpecLinux() {
 	g.initSpec()
 	if g.spec.Linux == nil {


### PR DESCRIPTION
Before modifying the spec's Hooks, check if the Hooks structure itself needs to be allocated.