### PR TITLE
Makefile: use -set_exit_status for golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test: .gofmt .govet .golint .gotest
 	go vet -x $(PACKAGES)
 
 .golint:
-	OUT=$$(golint $(PACKAGES)); if test -n "$${OUT}"; then echo "$${OUT}" && exit 1; fi
+	golint -set_exit_status $(PACKAGES)
 
 UTDIRS = ./validate/...
 .gotest:


### PR DESCRIPTION
We used to use this option but it's reverted
in #231 , not sure about the reason, it's simpler
than to use the OUT hack.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>