### PR TITLE
Fix ambient capability test case

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -44,7 +44,7 @@
 		},
 		{
 			"ImportPath": "github.com/syndtr/gocapability/capability",
-			"Rev": "e7cb7fa329f456b3855136a2642b197bad7366ba"
+			"Rev": "db04d3cc01c8b54962a58ec7e491717d06cfcc16"
 		},
 		{
 			"ImportPath": "github.com/urfave/cli",

--- a/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -428,11 +428,11 @@ func (c *capsV3) Load() (err error) {
 		}
 		if strings.HasPrefix(line, "CapB") {
 			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
-			break
+			continue
 		}
 		if strings.HasPrefix(line, "CapA") {
 			fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
-			break
+			continue
 		}
 	}
 	f.Close()


### PR DESCRIPTION
This patch updates the gocapability vendor package [1] so as not to
fail the ambient capability test case which 'make localvalidation'
invokes.

[1] Fix issue #12: break too early #13
    https://github.com/syndtr/gocapability/pull/13

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>