### PR TITLE
cmd/oci-runtime-tool/main.go: DRYer app.Version

### DIFF
--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -15,10 +15,9 @@ var gitCommit = ""
 func main() {
 	app := cli.NewApp()
 	app.Name = "oci-runtime-tool"
+	app.Version = "0.0.1"
 	if gitCommit != "" {
-		app.Version = fmt.Sprintf("0.0.1, commit: %s", gitCommit)
-	} else {
-		app.Version = "0.0.1"
+		app.Version += fmt.Sprintf(", commit: %s", gitCommit)
 	}
 	app.Usage = "OCI (Open Container Initiative) runtime tools"
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
Instead of hard-coding the current version in two locations, set it once and append the commit information if we have it.  After this change:

    $ git grep 0.0.1 | grep -v 'vendor\|Godeps'
    cmd/oci-runtime-tool/main.go:   app.Version = "0.0.1"
    cmd/runtimetest/main.go:        app.Version = "0.0.1"
    validate/validate_test.go:              {"0.0.1", false},

which is the best we can get without setting a `gitTag` `ldflag` or some such.