### PR TITLE
*: Fix --bind -> --mount-bind, etc.

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -623,11 +623,11 @@ func parseBindMount(s string) (string, string, []string, error) {
 	case 3:
 		source, dest, options = bparts[0], bparts[1], strings.Split(bparts[2], ":")
 	default:
-		return source, dest, options, fmt.Errorf("--bind should have format src:dest[:options...]")
+		return source, dest, options, fmt.Errorf("--mount-bind should have format src:dest[:options...]")
 	}
 
 	if source == "" || dest == "" {
-		return source, dest, options, fmt.Errorf("--bind should have format src:dest[:options...]")
+		return source, dest, options, fmt.Errorf("--mount-bind should have format src:dest[:options...]")
 	}
 	return source, dest, options, nil
 }

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -413,7 +413,7 @@ _oci-runtime-tool_generate() {
 			return
 			;;
 
-		--rootfs|--tmpfs|--bind|--cwd)
+		--rootfs|--tmpfs|--mount-bind|--cwd)
 			case "$cur" in
 				*:*)
 					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -413,7 +413,7 @@ _oci-runtime-tool_generate() {
 			return
 			;;
 
-		--rootfs|--tmpfs|--mount-bind|--process-cwd)
+		--rootfs-path|--tmpfs|--mount-bind|--process-cwd)
 			case "$cur" in
 				*:*)
 					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -413,7 +413,7 @@ _oci-runtime-tool_generate() {
 			return
 			;;
 
-		--rootfs|--tmpfs|--mount-bind|--cwd)
+		--rootfs|--tmpfs|--mount-bind|--process-cwd)
 			case "$cur" in
 				*:*)
 					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -350,7 +350,7 @@ tmpfs directories on /generate and /tmp.
 If you want messages that are logged in your container to show up in the host's
 syslog/journal then you should bind mount the /dev/log directory as follows.
 
-    $ oci-runtime-tool generate --bind /dev/log:/dev/log  --rootfs-path /var/lib/containers/fedora --args bash
+    $ oci-runtime-tool generate --mount-bind /dev/log:/dev/log  --rootfs-path /var/lib/containers/fedora --args bash
 
 From inside the container you can test this by sending a message to the log.
 


### PR DESCRIPTION
Which was missed in #371.

Also fix:

* `--cwd` → `--process-cwd` (missed in #371)
* `--rootfs` → `--rootfs-path` (missed in #254)