### PR TITLE
Rename CheckRootfsPath and add Root check for hyper-v

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -96,7 +96,7 @@ func NewValidatorFromPath(bundlePath string, hostSpecific bool, platform string)
 // CheckAll checks all parts of runtime bundle
 func (v *Validator) CheckAll() (msgs []string) {
 	msgs = append(msgs, v.CheckPlatform()...)
-	msgs = append(msgs, v.CheckRootfs()...)
+	msgs = append(msgs, v.CheckRoot()...)
 	msgs = append(msgs, v.CheckMandatoryFields()...)
 	msgs = append(msgs, v.CheckSemVer()...)
 	msgs = append(msgs, v.CheckMounts()...)
@@ -109,9 +109,20 @@ func (v *Validator) CheckAll() (msgs []string) {
 	return
 }
 
-// CheckRootfs checks status of v.spec.Root
-func (v *Validator) CheckRootfs() (msgs []string) {
-	logrus.Debugf("check rootfs")
+// CheckRoot checks status of v.spec.Root
+func (v *Validator) CheckRoot() (msgs []string) {
+	logrus.Debugf("check root")
+
+	if v.platform == "windows" && v.spec.Windows.HyperV != nil {
+		if v.spec.Root != nil {
+			msgs = append(msgs, fmt.Sprintf("for Hyper-V containers, Root must not be set"))
+			return
+		}
+		return
+	} else if v.spec.Root == nil {
+		msgs = append(msgs, fmt.Sprintf("for non-Hyper-V containers, Root must be set"))
+		return
+	}
 
 	absBundlePath, err := filepath.Abs(v.bundlePath)
 	if err != nil {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -96,7 +96,7 @@ func NewValidatorFromPath(bundlePath string, hostSpecific bool, platform string)
 // CheckAll checks all parts of runtime bundle
 func (v *Validator) CheckAll() (msgs []string) {
 	msgs = append(msgs, v.CheckPlatform()...)
-	msgs = append(msgs, v.CheckRootfsPath()...)
+	msgs = append(msgs, v.CheckRootfs()...)
 	msgs = append(msgs, v.CheckMandatoryFields()...)
 	msgs = append(msgs, v.CheckSemVer()...)
 	msgs = append(msgs, v.CheckMounts()...)
@@ -109,9 +109,9 @@ func (v *Validator) CheckAll() (msgs []string) {
 	return
 }
 
-// CheckRootfsPath checks status of v.spec.Root.Path
-func (v *Validator) CheckRootfsPath() (msgs []string) {
-	logrus.Debugf("check rootfs path")
+// CheckRootfs checks status of v.spec.Root
+func (v *Validator) CheckRootfs() (msgs []string) {
+	logrus.Debugf("check rootfs")
 
 	absBundlePath, err := filepath.Abs(v.bundlePath)
 	if err != nil {

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -18,10 +18,10 @@ func checkErrors(t *testing.T, title string, msgs []string, valid bool) {
 	}
 }
 
-func TestCheckRootfs(t *testing.T) {
+func TestCheckRoot(t *testing.T) {
 	tmpBundle, err := ioutil.TempDir("", "oci-check-rootfspath")
 	if err != nil {
-		t.Fatalf("Failed to create a TempDir in 'CheckRootfs'")
+		t.Fatalf("Failed to create a TempDir in 'CheckRoot'")
 	}
 	defer os.RemoveAll(tmpBundle)
 
@@ -29,10 +29,10 @@ func TestCheckRootfs(t *testing.T) {
 	rootfsNonDir := "rootfsfile"
 	rootfsNonExists := "rootfsnil"
 	if err := os.MkdirAll(filepath.Join(tmpBundle, rootfsDir), 0700); err != nil {
-		t.Fatalf("Failed to create a rootfs directory in 'CheckRootfs'")
+		t.Fatalf("Failed to create a rootfs directory in 'CheckRoot'")
 	}
 	if _, err := os.Create(filepath.Join(tmpBundle, rootfsNonDir)); err != nil {
-		t.Fatalf("Failed to create a non-directory rootfs in 'CheckRootfs'")
+		t.Fatalf("Failed to create a non-directory rootfs in 'CheckRoot'")
 	}
 
 	cases := []struct {
@@ -48,7 +48,7 @@ func TestCheckRootfs(t *testing.T) {
 	}
 	for _, c := range cases {
 		v := NewValidator(&rspec.Spec{Root: &rspec.Root{Path: c.val}}, tmpBundle, false, "linux")
-		checkErrors(t, "CheckRootfs "+c.val, v.CheckRootfs(), c.expected)
+		checkErrors(t, "CheckRoot "+c.val, v.CheckRoot(), c.expected)
 	}
 }
 

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -18,10 +18,10 @@ func checkErrors(t *testing.T, title string, msgs []string, valid bool) {
 	}
 }
 
-func TestCheckRootfsPath(t *testing.T) {
+func TestCheckRootfs(t *testing.T) {
 	tmpBundle, err := ioutil.TempDir("", "oci-check-rootfspath")
 	if err != nil {
-		t.Fatalf("Failed to create a TempDir in 'CheckRootfsPath'")
+		t.Fatalf("Failed to create a TempDir in 'CheckRootfs'")
 	}
 	defer os.RemoveAll(tmpBundle)
 
@@ -29,10 +29,10 @@ func TestCheckRootfsPath(t *testing.T) {
 	rootfsNonDir := "rootfsfile"
 	rootfsNonExists := "rootfsnil"
 	if err := os.MkdirAll(filepath.Join(tmpBundle, rootfsDir), 0700); err != nil {
-		t.Fatalf("Failed to create a rootfs directory in 'CheckRootfsPath'")
+		t.Fatalf("Failed to create a rootfs directory in 'CheckRootfs'")
 	}
 	if _, err := os.Create(filepath.Join(tmpBundle, rootfsNonDir)); err != nil {
-		t.Fatalf("Failed to create a non-directory rootfs in 'CheckRootfsPath'")
+		t.Fatalf("Failed to create a non-directory rootfs in 'CheckRootfs'")
 	}
 
 	cases := []struct {
@@ -48,7 +48,7 @@ func TestCheckRootfsPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		v := NewValidator(&rspec.Spec{Root: &rspec.Root{Path: c.val}}, tmpBundle, false, "linux")
-		checkErrors(t, "CheckRootfsPath "+c.val, v.CheckRootfsPath(), c.expected)
+		checkErrors(t, "CheckRootfs "+c.val, v.CheckRootfs(), c.expected)
 	}
 }
 


### PR DESCRIPTION
1. CheckRootfsPath does not only include Path check, we should rename it.
2. For Hyper-V container, Root must not be set.