### PR TITLE
error: Pull the RFC 2119 error representation into its own package

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -1,0 +1,87 @@
+// Package error implements generic tooling for tracking RFC 2119
+// violations and linking back to the appropriate specification section.
+package error
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Level represents the OCI compliance levels
+type Level int
+
+const (
+	// MAY-level
+
+	// May represents 'MAY' in RFC 2119.
+	May Level = iota
+	// Optional represents 'OPTIONAL' in RFC 2119.
+	Optional
+
+	// SHOULD-level
+
+	// Should represents 'SHOULD' in RFC 2119.
+	Should
+	// ShouldNot represents 'SHOULD NOT' in RFC 2119.
+	ShouldNot
+	// Recommended represents 'RECOMMENDED' in RFC 2119.
+	Recommended
+	// NotRecommended represents 'NOT RECOMMENDED' in RFC 2119.
+	NotRecommended
+
+	// MUST-level
+
+	// Must represents 'MUST' in RFC 2119
+	Must
+	// MustNot represents 'MUST NOT' in RFC 2119.
+	MustNot
+	// Shall represents 'SHALL' in RFC 2119.
+	Shall
+	// ShallNot represents 'SHALL NOT' in RFC 2119.
+	ShallNot
+	// Required represents 'REQUIRED' in RFC 2119.
+	Required
+)
+
+// Error represents an error with compliance level and OCI reference.
+type Error struct {
+	Level     Level
+	Reference string
+	Err       error
+}
+
+// ParseLevel takes a string level and returns the OCI compliance level constant.
+func ParseLevel(level string) (Level, error) {
+	switch strings.ToUpper(level) {
+	case "MAY":
+		fallthrough
+	case "OPTIONAL":
+		return May, nil
+	case "SHOULD":
+		fallthrough
+	case "SHOULDNOT":
+		fallthrough
+	case "RECOMMENDED":
+		fallthrough
+	case "NOTRECOMMENDED":
+		return Should, nil
+	case "MUST":
+		fallthrough
+	case "MUSTNOT":
+		fallthrough
+	case "SHALL":
+		fallthrough
+	case "SHALLNOT":
+		fallthrough
+	case "REQUIRED":
+		return Must, nil
+	}
+
+	var l Level
+	return l, fmt.Errorf("%q is not a valid compliance level", level)
+}
+
+// Error returns the error message with OCI reference
+func (err *Error) Error() string {
+	return fmt.Sprintf("%s\nRefer to: %s", err.Err.Error(), err.Reference)
+}


### PR DESCRIPTION
As discussed [here][1].  This makes it easier for other projects (e.g. image-tools) to use the same tooling if they want.  Some components of the old `validate/error.go` were runtime-spec-specific (e.g. the reference template and `ociErrors`), so they've stayed in the validate package.

I've also expanded `NewError` to take an explicit version (as requested [here][2]).  That allows us to link to the proper spec even if we're capable of validating several spec versions (e.g. 1.0 and 1.1 configurations or runtimes).

[1]: https://github.com/opencontainers/runtime-tools/pull/354#discussion_r109216291
[2]: https://github.com/opencontainers/runtime-tools/pull/354#discussion_r108980617