### PR TITLE
validate: avoid panic on nil fields

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -111,7 +111,7 @@ func (v *Validator) CheckAll() (msgs []string) {
 func (v *Validator) CheckRoot() (msgs []string) {
 	logrus.Debugf("check root")
 
-	if v.platform == "windows" && v.spec.Windows.HyperV != nil {
+	if v.platform == "windows" && v.spec.Windows != nil && v.spec.Windows.HyperV != nil {
 		if v.spec.Root != nil {
 			msgs = append(msgs, fmt.Sprintf("for Hyper-V containers, Root must not be set"))
 			return


### PR DESCRIPTION


```
➜  runtime-tools git:(master) ✗ ./oci-runtime-tool validate --platform windows 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x4cf70d]

goroutine 1 [running]:
panic(0x5aeb80, 0xc4200100f0)
	/home/zhouhao/go/src/runtime/panic.go:500 +0x1a1
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckRoot(0xc4200b77b0, 0xc4200c4610, 0x1, 0x1)
	/home/zhouhao/workspace/Go/src/github.com/opencontainers/runtime-tools/validate/validate.go:114 +0xf6d
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckAll(0xc4200b77b0, 0x1, 0x0, 0xc420010ab1)
	/home/zhouhao/workspace/Go/src/github.com/opencontainers/runtime-tools/validate/validate.go:99 +0xb2
main.glob.func2(0xc4200a4140, 0x0, 0x2200a4140)
	/home/zhouhao/workspace/Go/src/github.com/opencontainers/runtime-tools/cmd/oci-runtime-tool/validate.go:30 +0x140
github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.HandleAction(0x5a6dc0, 0x5f8238, 0xc4200a4140, 0xc42001c300, 0x0)
	/home/zhouhao/workspace/Go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/app.go:485 +0xd4
github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.Command.Run(0x5dcf3c, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5e141d, 0x16, 0x0, ...)
	/home/zhouhao/workspace/Go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/command.go:193 +0xb96
github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.(*App).Run(0xc4200924e0, 0xc42000c340, 0x4, 0x4, 0x0, 0x0)
```
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>