### PR TITLE
Makefile: Set CGO_ENABLED=0 for runtimetest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ tool:
 
 .PHONY: runtimetest
 runtimetest:
-	go build -tags "$(BUILDTAGS)" -o runtimetest ./cmd/runtimetest
+	CGO_ENABLED=0 go build -installsuffix cgo -tags "$(BUILDTAGS)" -o runtimetest ./cmd/runtimetest
 
 .PHONY: man
 man:


### PR DESCRIPTION
And also set `-installsuffix cgo`.  `runtimetest` is designed to be run from inside a container, which may include a mount namespace that has no linker or dynamic libraries.  These changes give us a static runtimetest binary which will work in those conditions.

The approach I'm using here follows [this suggestion][2].  RunC does things a bit differently (see opencontainers/runc#401), but I'm not familiar enough with Go to contrast the approaches.

[2]: https://github.com/golang/go/issues/9344#issuecomment-69944514