### PR TITLE
filepath: Add a stand-alone package for explicit-OS path logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,6 @@ test: .gofmt .govet .golint .gotest
 .golint:
 	golint -set_exit_status $(PACKAGES)
 
-UTDIRS = ./validate/...
+UTDIRS = ./filepath/... ./validate/...
 .gotest:
 	go test $(UTDIRS)

--- a/filepath/abs.go
+++ b/filepath/abs.go
@@ -1,0 +1,52 @@
+package filepath
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var windowsAbs = regexp.MustCompile(`^[a-zA-Z]:\\.*$`)
+
+// Abs is a version of path/filepath's Abs with an explicit operating
+// system and current working directory.
+func Abs(os, path, cwd string) (_ string, err error) {
+	if os == "windows" {
+		return "", errors.New("Abs() does not support windows yet")
+	}
+	if IsAbs(os, path) {
+		return Clean(os, path), nil
+	}
+	return Clean(os, Join(os, cwd, path)), nil
+}
+
+// IsAbs is a version of path/filepath's IsAbs with an explicit
+// operating system.
+func IsAbs(os, path string) bool {
+	if os == "windows" {
+		// FIXME: copy hideous logic from Go's
+		// src/path/filepath/path_windows.go into somewhere where we can
+		// put 3-clause BSD licensed code.
+		return windowsAbs.MatchString(path)
+	}
+	sep := Separator(os)
+
+	// POSIX has [1]:
+	//
+	// > If a pathname begins with two successive <slash> characters,
+	// > the first component following the leading <slash> characters
+	// > may be interpreted in an implementation-defined manner,
+	// > although more than two leading <slash> characters shall be
+	// > treated as a single <slash> character.
+	//
+	// And Boost treats // as non-absolute [2], but Linux [3,4], Python
+	// [5] and Go [6] all treat // as absolute.
+	//
+	// [1]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+	// [2]: https://github.com/boostorg/filesystem/blob/boost-1.64.0/test/path_test.cpp#L861
+	// [3]: http://man7.org/linux/man-pages/man7/path_resolution.7.html
+	// [4]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/filesystems/path-lookup.md?h=v4.12#n41
+	// [5]: https://github.com/python/cpython/blob/v3.6.1/Lib/posixpath.py#L64-L66
+	// [6]: https://go.googlesource.com/go/+/go1.8.3/src/path/path.go#199
+	return strings.HasPrefix(path, string(sep))
+}

--- a/filepath/abs_test.go
+++ b/filepath/abs_test.go
@@ -1,0 +1,171 @@
+package filepath
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAbs(t *testing.T) {
+	for _, test := range []struct {
+		os       string
+		path     string
+		cwd      string
+		expected string
+	}{
+		{
+			os:       "linux",
+			path:     "/",
+			cwd:      "/cwd",
+			expected: "/",
+		},
+		{
+			os:       "linux",
+			path:     "/a",
+			cwd:      "/cwd",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     "/a/",
+			cwd:      "/cwd",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     "//a",
+			cwd:      "/cwd",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     ".",
+			cwd:      "/cwd",
+			expected: "/cwd",
+		},
+		{
+			os:       "linux",
+			path:     "./c",
+			cwd:      "/a/b",
+			expected: "/a/b/c",
+		},
+		{
+			os:       "linux",
+			path:     ".//c",
+			cwd:      "/a/b",
+			expected: "/a/b/c",
+		},
+		{
+			os:       "linux",
+			path:     "../a",
+			cwd:      "/cwd",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     "../../b",
+			cwd:      "/cwd",
+			expected: "/b",
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("Abs(%q,%q,%q)", test.os, test.path, test.cwd),
+			func(t *testing.T) {
+				abs, err := Abs(test.os, test.path, test.cwd)
+				if err != nil {
+					t.Error(err)
+				} else if abs != test.expected {
+					t.Errorf("unexpected result: %q (expected %q)\n", abs, test.expected)
+				}
+			},
+		)
+	}
+}
+
+func TestIsAbs(t *testing.T) {
+	for _, test := range []struct {
+		os       string
+		path     string
+		expected bool
+	}{
+		{
+			os:       "linux",
+			path:     "/",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			path:     "/a",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			path:     "//",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			path:     "//a",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			path:     ".",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			path:     "./a",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			path:     ".//a",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			path:     "../a",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			path:     "../../a",
+			expected: false,
+		},
+		{
+			os:       "windows",
+			path:     "c:\\",
+			expected: true,
+		},
+		{
+			os:       "windows",
+			path:     "c:\\a",
+			expected: true,
+		},
+		{
+			os:       "windows",
+			path:     ".",
+			expected: false,
+		},
+		{
+			os:       "windows",
+			path:     ".\\a",
+			expected: false,
+		},
+		{
+			os:       "windows",
+			path:     "..\\a",
+			expected: false,
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("IsAbs(%q,%q)", test.os, test.path),
+			func(t *testing.T) {
+				abs := IsAbs(test.os, test.path)
+				if abs != test.expected {
+					t.Errorf("unexpected result: %t (expected %t)\n", abs, test.expected)
+				}
+			},
+		)
+	}
+}

--- a/filepath/ancestor.go
+++ b/filepath/ancestor.go
@@ -1,0 +1,32 @@
+package filepath
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsAncestor returns true when pathB is an strict ancestor of pathA,
+// and false where the paths are equal or pathB is outside of pathA.
+// Paths that are not absolute will be made absolute with Abs.
+func IsAncestor(os, pathA, pathB, cwd string) (_ bool, err error) {
+	if pathA == pathB {
+		return false, nil
+	}
+
+	pathA, err = Abs(os, pathA, cwd)
+	if err != nil {
+		return false, err
+	}
+	pathB, err = Abs(os, pathB, cwd)
+	if err != nil {
+		return false, err
+	}
+	sep := Separator(os)
+	if !strings.HasSuffix(pathA, string(sep)) {
+		pathA = fmt.Sprintf("%s%c", pathA, sep)
+	}
+	if pathA == pathB {
+		return false, nil
+	}
+	return strings.HasPrefix(pathB, pathA), nil
+}

--- a/filepath/ancestor_test.go
+++ b/filepath/ancestor_test.go
@@ -1,0 +1,113 @@
+package filepath
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsAncestor(t *testing.T) {
+	for _, test := range []struct {
+		os       string
+		pathA    string
+		pathB    string
+		cwd      string
+		expected bool
+	}{
+		{
+			os:       "linux",
+			pathA:    "/",
+			pathB:    "/a",
+			cwd:      "/cwd",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "/a",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "/",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "/ab",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a/",
+			pathB:    "/a",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "//a",
+			pathB:    "/a",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "//a",
+			pathB:    "/a/b",
+			cwd:      "/cwd",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "/a/",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    ".",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "b",
+			cwd:      "/a",
+			expected: true,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "../a",
+			cwd:      "/cwd",
+			expected: false,
+		},
+		{
+			os:       "linux",
+			pathA:    "/a",
+			pathB:    "../a/b",
+			cwd:      "/cwd",
+			expected: true,
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("IsAncestor(%q,%q,%q,%q)", test.os, test.pathA, test.pathB, test.cwd),
+			func(t *testing.T) {
+				ancestor, err := IsAncestor(test.os, test.pathA, test.pathB, test.cwd)
+				if err != nil {
+					t.Error(err)
+				} else if ancestor != test.expected {
+					t.Errorf("unexpected result: %t", ancestor)
+				}
+			},
+		)
+	}
+}

--- a/filepath/clean.go
+++ b/filepath/clean.go
@@ -1,0 +1,56 @@
+package filepath
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Clean is an explicit-OS version of path/filepath's Clean.
+func Clean(os, path string) string {
+	abs := IsAbs(os, path)
+	sep := Separator(os)
+	elements := strings.Split(path, string(sep))
+
+	// Replace multiple Separator elements with a single one.
+	for i := 0; i < len(elements); i++ {
+		if len(elements[i]) == 0 {
+			elements = append(elements[:i], elements[i+1:]...)
+			i--
+		}
+	}
+
+	// Eliminate each . path name element (the current directory).
+	for i := 0; i < len(elements); i++ {
+		if elements[i] == "." && len(elements) > 1 {
+			elements = append(elements[:i], elements[i+1:]...)
+			i--
+		}
+	}
+
+	// Eliminate each inner .. path name element (the parent directory)
+	// along with the non-.. element that precedes it.
+	for i := 1; i < len(elements); i++ {
+		if i > 0 && elements[i] == ".." {
+			elements = append(elements[:i-1], elements[i+1:]...)
+			i -= 2
+		}
+	}
+
+	// Eliminate .. elements that begin a rooted path:
+	// that is, replace "/.." by "/" at the beginning of a path,
+	// assuming Separator is '/'.
+	if abs && len(elements) > 0 {
+		for elements[0] == ".." {
+			elements = elements[1:]
+		}
+	}
+
+	cleaned := strings.Join(elements, string(sep))
+	if abs {
+		cleaned = fmt.Sprintf("%c%s", sep, cleaned)
+	}
+	if cleaned == path {
+		return path
+	}
+	return Clean(os, cleaned)
+}

--- a/filepath/clean_test.go
+++ b/filepath/clean_test.go
@@ -1,0 +1,70 @@
+package filepath
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClean(t *testing.T) {
+	for _, test := range []struct {
+		os       string
+		path     string
+		expected string
+	}{
+		{
+			os:       "linux",
+			path:     "/",
+			expected: "/",
+		},
+		{
+			os:       "linux",
+			path:     "//",
+			expected: "/",
+		},
+		{
+			os:       "linux",
+			path:     "/a",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     "/a/",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     "//a",
+			expected: "/a",
+		},
+		{
+			os:       "linux",
+			path:     ".",
+			expected: ".",
+		},
+		{
+			os:       "linux",
+			path:     "./c",
+			expected: "c",
+		},
+		{
+			os:       "linux",
+			path:     ".././a",
+			expected: "../a",
+		},
+		{
+			os:       "linux",
+			path:     "a/../b",
+			expected: "b",
+		},
+	} {
+		t.Run(
+			fmt.Sprintf("Clean(%q,%q)", test.os, test.path),
+			func(t *testing.T) {
+				clean := Clean(test.os, test.path)
+				if clean != test.expected {
+					t.Errorf("unexpected result: %q (expected %q)\n", clean, test.expected)
+				}
+			},
+		)
+	}
+}

--- a/filepath/doc.go
+++ b/filepath/doc.go
@@ -1,0 +1,6 @@
+// Package filepath implements Go's filepath package with explicit
+// operating systems (and for some functions and explicit working
+// directory).  This allows tools built for one OS to operate on paths
+// targeting another OS.  For example, a Linux build can determine
+// whether a path is absolute on Linux or on Windows.
+package filepath

--- a/filepath/join.go
+++ b/filepath/join.go
@@ -1,0 +1,9 @@
+package filepath
+
+import "strings"
+
+// Join is an explicit-OS version of path/filepath's Join.
+func Join(os string, elem ...string) string {
+	sep := Separator(os)
+	return Clean(os, strings.Join(elem, string(sep)))
+}

--- a/filepath/separator.go
+++ b/filepath/separator.go
@@ -1,0 +1,9 @@
+package filepath
+
+// Separator is an explicit-OS version of path/filepath's Separator.
+func Separator(os string) rune {
+	if os == "windows" {
+		return '\\'
+	}
+	return '/'
+}


### PR DESCRIPTION
As discussed [here][0] and later, and based on the Gist I'd created for that comment.

Go's path/filepath has lots of useful path operations, but there is a compile-time decision to select only the logic that applies to your `$GOOS`.  That makes it hard to validate a Windows config from a Linux host (or vice versa) because Go's builtin tools won't tell you whether a path is absolute on the target platform (just whether the path is absolute on *your* platform).  This commit adds a new package to do the same sorts of things but with an explicit OS argument.

In some cases, there's also an explicit workding directory argument. For example, Go's [`Abs`][1] has:

> If the path is not absolute it will be joined with the current working directory to turn it into an absolute path.

but that doesn't make sense for a cross-platform `Abs` call because the real current working directory will be for the wrong platform.  Instead, cross-platform calls to `Abs` and similar should fake a working directory as if they were being called from the other platform.

The Windows implementation is not very complete, with `IsAbs` definitely missing a lot of stuff; `Abs`, `Clean`, and `IsAncestor` probably missing stuff; and a lack of Windows-path tests.  But the current tools are broken for validating Windows configs anyway, so I've left completing Windows support to future work.

Besides adding the new package, I updated the config validation to use the new package where appropriate.  For example, checks for absolute hook paths (based on [this][2]) now appropriately account for the target platform (although `Abs` has limited Windows support at the moment, as mentioned above).

There are still a number of config validation checks that use Go's stock filepath, because they're based around actual filesystem access (e.g. reading `config.json` off the disk, asserting that `root.path` exists on the disk, etc.).  Some of those will need logic to convert between path platforms (which I'm leaving to future work).  For example, if `root.path` is formed for another platform, then:

* If `root.path` is absolute (on the target platform), there's no way to check whether root.path exists inside the bundle.
* If `root.path` is relative, we should be converting it from the target platform to the host platform before joining it to our bundle path.  For example, with a Windows bundle in `/foo` on a Linux host where `root.path` is `bar\baz`, then runtime-tools should be checking for the root directory in `/foo/bar/baz`, not in `/foo/bar\baz`.  The `root.path` example is somewhat guarded by the [bundle requirement for siblinghood][3], but I'd rather enforce siblinghood independently from existence, since the spec has [separate][3] [requirements][4] for both.

[0]: https://github.com/opencontainers/runtime-tools/pull/256#issuecomment-258365559
[1]: https://golang.org/pkg/path/filepath/#Abs
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/config.md#L375
[3]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/bundle.md#L17-L19
[4]: https://github.com/opencontainers/runtime-spec/blame/v1.0.0/config.md#L43