### PR TITLE
specerror: Pull runtime-spec-specific error handling into its own package

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// Level represents the OCI compliance levels
+// Level represents the RFC 2119 compliance levels
 type Level int
 
 const (
@@ -43,14 +43,19 @@ const (
 	Required
 )
 
-// Error represents an error with compliance level and OCI reference.
+// Error represents an error with compliance level and specification reference.
 type Error struct {
-	Level     Level
+	// Level represents the RFC 2119 compliance level.
+	Level Level
+
+	// Reference is a URL for the violated specification requirement.
 	Reference string
-	Err       error
+
+	// Err holds additional details about the violation.
+	Err error
 }
 
-// ParseLevel takes a string level and returns the OCI compliance level constant.
+// ParseLevel takes a string level and returns the RFC 2119 compliance level constant.
 func ParseLevel(level string) (Level, error) {
 	switch strings.ToUpper(level) {
 	case "MAY":
@@ -81,7 +86,7 @@ func ParseLevel(level string) (Level, error) {
 	return l, fmt.Errorf("%q is not a valid compliance level", level)
 }
 
-// Error returns the error message with OCI reference
+// Error returns the error message with specification reference.
 func (err *Error) Error() string {
 	return fmt.Sprintf("%s\nRefer to: %s", err.Err.Error(), err.Reference)
 }

--- a/error/error.go
+++ b/error/error.go
@@ -48,7 +48,6 @@ type Error struct {
 	Level     Level
 	Reference string
 	Err       error
-	ErrCode   int
 }
 
 // ParseLevel takes a string level and returns the OCI compliance level constant.

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -11,7 +11,7 @@ import (
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 
-	rerr "github.com/opencontainers/runtime-tools/error"
+	"github.com/opencontainers/runtime-tools/specerror"
 )
 
 func TestNewValidator(t *testing.T) {
@@ -53,40 +53,40 @@ func TestCheckRoot(t *testing.T) {
 	cases := []struct {
 		val      rspec.Spec
 		platform string
-		expected rerr.SpecErrorCode
+		expected specerror.Code
 	}{
-		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: &rspec.Root{}}, "windows", rerr.RootOnHyperV},
-		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: nil}, "windows", rerr.NonError},
-		{rspec.Spec{Root: nil}, "linux", rerr.RootOnNonHyperV},
-		{rspec.Spec{Root: &rspec.Root{Path: "maverick-rootfs"}}, "linux", rerr.PathName},
-		{rspec.Spec{Root: &rspec.Root{Path: "rootfs"}}, "linux", rerr.NonError},
-		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, rootfsNonExists)}}, "linux", rerr.PathExistence},
-		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, rootfsNonDir)}}, "linux", rerr.PathExistence},
-		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, "rootfs")}}, "linux", rerr.NonError},
-		{rspec.Spec{Root: &rspec.Root{Path: "rootfs/rootfs"}}, "linux", rerr.ArtifactsInSingleDir},
-		{rspec.Spec{Root: &rspec.Root{Readonly: true}}, "windows", rerr.ReadonlyOnWindows},
+		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: &rspec.Root{}}, "windows", specerror.RootOnHyperV},
+		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: nil}, "windows", specerror.NonError},
+		{rspec.Spec{Root: nil}, "linux", specerror.RootOnNonHyperV},
+		{rspec.Spec{Root: &rspec.Root{Path: "maverick-rootfs"}}, "linux", specerror.PathName},
+		{rspec.Spec{Root: &rspec.Root{Path: "rootfs"}}, "linux", specerror.NonError},
+		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, rootfsNonExists)}}, "linux", specerror.PathExistence},
+		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, rootfsNonDir)}}, "linux", specerror.PathExistence},
+		{rspec.Spec{Root: &rspec.Root{Path: filepath.Join(tmpBundle, "rootfs")}}, "linux", specerror.NonError},
+		{rspec.Spec{Root: &rspec.Root{Path: "rootfs/rootfs"}}, "linux", specerror.ArtifactsInSingleDir},
+		{rspec.Spec{Root: &rspec.Root{Readonly: true}}, "windows", specerror.ReadonlyOnWindows},
 	}
 	for _, c := range cases {
 		v := NewValidator(&c.val, tmpBundle, false, c.platform)
 		err := v.CheckRoot()
-		assert.Equal(t, c.expected, rerr.FindError(err, c.expected), fmt.Sprintf("Fail to check Root: %v %d", err, c.expected))
+		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), fmt.Sprintf("Fail to check Root: %v %d", err, c.expected))
 	}
 }
 
 func TestCheckSemVer(t *testing.T) {
 	cases := []struct {
 		val      string
-		expected rerr.SpecErrorCode
+		expected specerror.Code
 	}{
-		{rspec.Version, rerr.NonError},
+		{rspec.Version, specerror.NonError},
 		//FIXME: validate currently only handles rpsec.Version
-		{"0.0.1", rerr.NonRFCError},
-		{"invalid", rerr.SpecVersion},
+		{"0.0.1", specerror.NonRFCError},
+		{"invalid", specerror.SpecVersion},
 	}
 
 	for _, c := range cases {
 		v := NewValidator(&rspec.Spec{Version: c.val}, "", false, "linux")
 		err := v.CheckSemVer()
-		assert.Equal(t, c.expected, rerr.FindError(err, c.expected), "Fail to check SemVer "+c.val)
+		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), "Fail to check SemVer "+c.val)
 	}
 }

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,8 +13,8 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 
-	rerr "github.com/opencontainers/runtime-tools/error"
 	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/opencontainers/runtime-tools/specerror"
 )
 
 var (
@@ -114,9 +115,9 @@ func TestValidateCreate(t *testing.T) {
 		errExpected bool
 		err         error
 	}{
-		{"", false, rerr.NewError(rerr.CreateWithID, "'Create' MUST generate an error if the ID is not provided", rspecs.Version)},
-		{containerID, true, rerr.NewError(rerr.CreateNewContainer, "'Create' MUST create a new container", rspecs.Version)},
-		{containerID, false, rerr.NewError(rerr.CreateWithUniqueID, "'Create' MUST generate an error if the ID provided is not unique", rspecs.Version)},
+		{"", false, specerror.NewError(specerror.CreateWithID, fmt.Errorf("create MUST generate an error if the ID is not provided"), rspecs.Version)},
+		{containerID, true, specerror.NewError(specerror.CreateNewContainer, fmt.Errorf("create MUST create a new container"), rspecs.Version)},
+		{containerID, false, specerror.NewError(specerror.CreateWithUniqueID, fmt.Errorf("create MUST generate an error if the ID provided is not unique"), rspecs.Version)},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
With #437, I'd created a package that was completely independent of runtime-spec.  As I pointed out in that PR, this made it possible for image-tools and other projects to reuse the generic RFC 2119 handling (which they care about) without involving the runtime-spec-specific error enumeration and such (which they don't care about).

In #451, some runtime-spec-specific functionality leaked into the error package.  I'd recommended [keeping configuration and runtime requirements separate][1], because you're unlikely to be testing both of those at once.  But @liangchenye [wanted][2] them [collected][3].  And the `NewError` and `FindError` utilities would be the same regardless of target, so that's a good argument for keeping them together.  This commit moves the runtime-spec-specific functionality into a new `specerror` package where both config and runtime validators can share it, but where it won't pollute the generic RFC 2119 `error` package.

I've also changed `NewError` to take an error argument instead of a string message, because creating an error from a string is easy (e.g. with `fmt.Errorf(…)`), and using an error allows you to preserve any additional structured information from a system error (e.g. as returned by `GetMounts`).

The second commit in this PR cleans up some of the generic RFC 2119 package's godocs.

[1]: https://github.com/opencontainers/runtime-tools/pull/451#discussion_r135844806
[2]: https://github.com/opencontainers/runtime-tools/pull/451#discussion_r135953382
[3]: https://github.com/opencontainers/runtime-tools/pull/451#issuecomment-325874457