### PR TITLE
validate: modify the condition of the deviceValid

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -920,7 +920,7 @@ func deviceValid(d rspec.LinuxDevice) bool {
 			return false
 		}
 	case "p":
-		if d.Major > 0 || d.Minor > 0 {
+		if d.Major != 0 || d.Minor != 0 {
 			return false
 		}
 	default:


### PR DESCRIPTION
Accord to the [mknod(1)](http://man7.org/linux/man-pages/man1/mknod.1.html). We can get the following information:

> Both MAJOR and MINOR must be specified when TYPE is b, c, or u, and they must be omitted when TYPE is p.

Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>