### PR TITLE
generate: do not validate caps when being dropped

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1029,7 +1029,7 @@ func (g *Generator) AddProcessCapability(c string) error {
 // DropProcessCapability drops a process capability from g.spec.Process.Capabilities.
 func (g *Generator) DropProcessCapability(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := validate.CapValid(cp, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There's actually little value in erroring out when asked to drop a
capability not supported on a system. This patch simply removes the cap
validation and just go ahead and drop the capability.

@mrunalp @Mashimiao PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>