### PR TITLE
reform to suppport mulitple runtimes

### DIFF
--- a/validation/runtime.go
+++ b/validation/runtime.go
@@ -1,0 +1,49 @@
+package validation
+
+import (
+	"fmt"
+	rspecs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/generate"
+)
+
+// ContainerOperation represents common funtions for container testing
+type ContainerOperation interface {
+	// SetConfig creates a 'config.json' by the generator
+	SetConfig(g *generate.Generator) error
+
+	// SetID sets the container ID
+	SetID(id string)
+
+	// Create a container
+	Create() error
+
+	// Start a container
+	Start() error
+
+	// State a container information
+	State() (rspecs.State, error)
+
+	// Delete a container
+	Delete() error
+
+	// Clean deletes the container and removes the bundle file according to the input parameter
+	Clean(removeBundle bool) error
+}
+
+// Runtime represents the basic requirement of a container runtime
+type Runtime struct {
+	RuntimeCommand string
+	BundleDir      string
+	ID             string
+}
+
+// NewRuntime creates different runtime based on runtimeCommand
+func NewRuntime(runtimeCommand string, bundleDir string) (ContainerOperation, error) {
+	switch runtimeCommand {
+	case "runc":
+		r, err := NewRunc(runtimeCommand, bundleDir)
+		return r, err
+	}
+
+	return nil, fmt.Errorf("%s is not supported yet", runtimeCommand)
+}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -68,7 +68,7 @@ func runtimeInsideValidate(g *generate.Generator) error {
 	if err != nil {
 		return err
 	}
-	err = fileutils.CopyFile("../runtimetest", filepath.Join(r.BundleDir, "runtimetest"))
+	err = fileutils.CopyFile("../runtimetest", filepath.Join(bundleDir, "runtimetest"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

The spec does not specify any command-line APIs, so different runtime may have different APIs.
I create ContainerOperation interface and let Runtime to be parent structure, then we can implement them for different runtimes