### PR TITLE
validate: add root.path validation when platform is windows

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1089,11 +1089,7 @@ func (g *Generator) DropProcessCapability(c string) error {
 		}
 	}
 
-	if err := validate.CapValid(cp, false); err != nil {
-		return err
-	}
-
-	return nil
+	return validate.CapValid(cp, false)
 }
 
 func mapStrToNamespace(ns string, path string) (rspec.LinuxNamespace, error) {

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -114,6 +114,8 @@ func TestCheckRoot(t *testing.T) {
 	}{
 		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: &rspec.Root{}}, "windows", specerror.RootOnHyperV},
 		{rspec.Spec{Windows: &rspec.Windows{HyperV: &rspec.WindowsHyperV{}}, Root: nil}, "windows", specerror.NonError},
+		{rspec.Spec{Windows: &rspec.Windows{}, Root: &rspec.Root{Path: filepath.Join(tmpBundle, "rootfs")}}, "windows", specerror.PathFormatOnWindows},
+		{rspec.Spec{Windows: &rspec.Windows{}, Root: &rspec.Root{Path: "\\\\?\\Volume{ec84d99e-3f02-11e7-ac6c-00155d7682cf}\\"}}, "windows", specerror.NonError},
 		{rspec.Spec{Root: nil}, "linux", specerror.RootOnNonHyperV},
 		{rspec.Spec{Root: &rspec.Root{Path: "maverick-rootfs"}}, "linux", specerror.PathName},
 		{rspec.Spec{Root: &rspec.Root{Path: "rootfs"}}, "linux", specerror.NonError},


### PR DESCRIPTION
According to the [spec.](https://github.com/opencontainers/runtime-spec/blame/master/config.md#L37)

>On Windows, path MUST be a volume GUID path.


Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>