### PR TITLE
validate/validate_test: Handle JSON Schema test not raising an error

### DIFF
--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -75,6 +75,9 @@ func TestJSONSchema(t *testing.T) {
 				assert.Equal(t, nil, errs)
 				return
 			}
+			if errs == nil {
+				t.Fatal("failed to raise the expected error")
+			}
 			merr, ok := errs.(*multierror.Error)
 			if !ok {
 				t.Fatalf("non-multierror returned by CheckJSONSchema: %s", errs.Error())


### PR DESCRIPTION
Without this, tests that expect an error tried to cast the `nil` to a multierror (which failed) and then tried to format a failure message with `errs.Error()` (which panicked).