### PR TITLE
validate/validate_test: Better error messages for unexpected JSON Schema errors

### DIFF
--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -72,8 +72,10 @@ func TestJSONSchema(t *testing.T) {
 			v := &Validator{spec: tt.config}
 			errs := v.CheckJSONSchema()
 			if tt.error == "" {
-				assert.Equal(t, nil, errs)
-				return
+				if errs == nil {
+					return
+				}
+				t.Fatalf("expected no error, but got: %s", errs.Error())
 			}
 			merr, ok := errs.(*multierror.Error)
 			if !ok {


### PR DESCRIPTION
Instead of raising messages like:

```
  Error:  Not equal:
          expected: <nil>(<nil>)
          actual:
            *multierror.Error(*multierror.Error{Errors:[]error{(*errors.errorString)(0xc42037adc0)},
            ErrorFormat:(multierror.ErrorFormatFunc)(nil)})
```

raise messages like:

```
  * linux.rootfsPropagation: linux.rootfsPropagation must be one of
      the following: "private", "shared", "slave", "unbindable"
```