### PR TITLE
validate/validate_test: Add linux.rootfsPropagation checks

### DIFF
--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -63,6 +63,40 @@ func TestJSONSchema(t *testing.T) {
 		},
 		{
 			config: &rspec.Spec{
+				Version: "1.0.0",
+				Linux:   &rspec.Linux{},
+			},
+			error: "",
+		},
+		{
+			config: &rspec.Spec{
+				Version: "1.0.0",
+				Linux: &rspec.Linux{
+					RootfsPropagation: "",
+				},
+			},
+			error: "",
+		},
+		{
+			config: &rspec.Spec{
+				Version: "1.0.0",
+				Linux: &rspec.Linux{
+					RootfsPropagation: "shared",
+				},
+			},
+			error: "",
+		},
+		{
+			config: &rspec.Spec{
+				Version: "1.0.0",
+				Linux: &rspec.Linux{
+					RootfsPropagation: "rshared",
+				},
+			},
+			error: "linux.rootfsPropagation: linux.rootfsPropagation must be one of the following: \"private\", \"shared\", \"slave\", \"unbindable\"",
+		},
+		{
+			config: &rspec.Spec{
 				Version: "1.0.0-rc5",
 			},
 			error: "process: process is required",


### PR DESCRIPTION
To demonstrate that this is covered by the 1.0.0 JSON Schema checks, and show that the omitempty protects us from errors for empty-string values despite there being no empty-string entry in [the JSON Schema][1].

These tests are in support for #473.

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/schema/defs-linux.json#L4-L11