### PR TITLE
release: v0.2.0

### DIFF
--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -16,9 +16,9 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "oci-runtime-tool"
 	if gitCommit != "" {
-		app.Version = fmt.Sprintf("0.1.0, commit: %s", gitCommit)
+		app.Version = fmt.Sprintf("0.2.0, commit: %s", gitCommit)
 	} else {
-		app.Version = "0.1.0"
+		app.Version = "0.2.0"
 	}
 	app.Usage = "OCI (Open Container Initiative) runtime tools"
 	app.Flags = []cli.Flag{

--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -791,7 +791,7 @@ func run(context *cli.Context) error {
 func main() {
 	app := cli.NewApp()
 	app.Name = "runtimetest"
-	app.Version = "0.1.0"
+	app.Version = "0.2.0"
 	app.Usage = "Compare the environment with an OCI configuration"
 	app.Description = "runtimetest compares its current environment with an OCI runtime configuration read from config.json in its current working directory.  The tests are fairly generic and cover most configurations used by the runtime validation suite, but there are corner cases where a container launched by a valid runtime would not satisfy runtimetest."
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

This release covers almost all validation items for OCI bundle, contains the following changes since v0.1.0:
894cae7 validate/validate: Linux rlimits extend the POSIX rlimits
4f756fd Specific cap-drop command
ea55f9d Specific cap-add command
5cb6c48 rootfs.tar.gz: Bump to BusyBox 1.25.1
1a9532e generate: remove redundant content
567f1aa validate: add root.path validation when platform is windows
2cbb341 validate/validate_test: Add linux.rootfsPropagation checks
6e7da81 validate/validate_test: Better error messages for unexpected JSON Schema errors
4a705c6 validate/validate_test: Handle JSON Schema test not raising an error
16be985 validate: Delete the extra validation
3935592 Godeps: Include github.com/xeipuuv/gojsonschema
6e940f8 validate: Check configuration against JSON Schema
e666f92 cap: drop existent item before validating
766302b generate: do not validate caps when being dropped
4524149 validate: Remove the wrong seccompAction valid value
26cd89b fix broken cap completion
98b055d generate: fix cap add/drop and initialize in privileged mode
0ad3376 cmd: modify the err judgment