### PR TITLE
validate: allow unset "type" fields in resource devices whitelist

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -41,7 +41,7 @@ func New() Generator {
 	spec := rspec.Spec{
 		Version: rspec.Version,
 		Root: &rspec.Root{
-			Path:     "",
+			Path:     "rootfs",
 			Readonly: false,
 		},
 		Process: &rspec.Process{

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -749,7 +749,7 @@ func (v *Validator) CheckLinuxResources() (errs error) {
 	}
 	for index := 0; index < len(r.Devices); index++ {
 		switch r.Devices[index].Type {
-		case "a", "b", "c":
+		case "a", "b", "c", "":
 		default:
 			errs = multierror.Append(errs, fmt.Errorf("type of devices %s is invalid", r.Devices[index].Type))
 		}

--- a/validation/generate_test.go
+++ b/validation/generate_test.go
@@ -1,0 +1,56 @@
+package validation
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	rfc2119 "github.com/opencontainers/runtime-tools/error"
+	"github.com/opencontainers/runtime-tools/generate"
+	"github.com/opencontainers/runtime-tools/specerror"
+	"github.com/opencontainers/runtime-tools/validate"
+)
+
+// Smoke test to ensure that _at the very least_ our default configuration
+// passes the validation tests. If this test fails, something is _very_ wrong
+// and needs to be fixed immediately (as it will break downstreams that depend
+// on us for a "sane default" and do compliance testing -- such as umoci).
+func TestGenerateValid(t *testing.T) {
+	bundle, err := ioutil.TempDir("", "TestGenerateValid_bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(bundle)
+
+	// Create our toy bundle.
+	rootfsPath := filepath.Join(bundle, "rootfs")
+	if err := os.Mkdir(rootfsPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(bundle, "config.json")
+	g := generate.New()
+	if err := (&g).SaveToFile(configPath, generate.ExportOptions{Seccomp: false}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate the bundle.
+	v, err := validate.NewValidatorFromPath(bundle, true, runtime.GOOS)
+	if err != nil {
+		t.Errorf("unexpected NewValidatorFromPath error: %+v", err)
+	}
+	if err := v.CheckAll(); err != nil {
+		levelErrors, err := specerror.SplitLevel(err, rfc2119.Must)
+		if err != nil {
+			t.Errorf("unexpected non-multierror: %+v", err)
+			return
+		}
+		for _, e := range levelErrors.Warnings {
+			t.Logf("unexpected warning: %v", e)
+		}
+		if err := levelErrors.Error; err != nil {
+			t.Errorf("unexpected MUST error(s): %+v", err)
+		}
+	}
+}


### PR DESCRIPTION
According to the spec, an unset .Type field in the
.Linux.Resources.Devices list is permitted (and it maps to "all").
This was broken recently, making our own default profile (as well as
umoci's and runc's) not pass validation anymore.

Signed-off-by: Aleksa Sarai <asarai@suse.de>