### PR TITLE
cmd/oci-runtime-tool: Implement --compliance-level

### DIFF
--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -22,6 +22,11 @@ func main() {
 	}
 	app.Usage = "OCI (Open Container Initiative) runtime tools"
 	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "compliance-level",
+			Value: "must",
+			Usage: "compliance level (may, should, or must).",
+		},
 		cli.BoolFlag{
 			Name:  "host-specific",
 			Usage: "generate host-specific configs or do host-specific validations",

--- a/cmd/oci-runtime-tool/validate.go
+++ b/cmd/oci-runtime-tool/validate.go
@@ -3,7 +3,11 @@ package main
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
+	rfc2119 "github.com/opencontainers/runtime-tools/error"
+	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validate"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -19,6 +23,12 @@ var bundleValidateCommand = cli.Command{
 	Before: before,
 	Action: func(context *cli.Context) error {
 		hostSpecific := context.GlobalBool("host-specific")
+		complianceLevelString := context.GlobalString("compliance-level")
+		complianceLevel, err := rfc2119.ParseLevel(complianceLevelString)
+		if err != nil {
+			complianceLevel = rfc2119.Must
+			logrus.Warningf("%s, using 'MUST' by default.", err.Error())
+		}
 		inputPath := context.String("path")
 		platform := context.String("platform")
 		v, err := validate.NewValidatorFromPath(inputPath, hostSpecific, platform)
@@ -27,8 +37,20 @@ var bundleValidateCommand = cli.Command{
 		}
 
 		if err := v.CheckAll(); err != nil {
-			return err
-
+			merr, ok := err.(*multierror.Error)
+			if !ok {
+				return err
+			}
+			var validationErrors error
+			for _, err = range merr.Errors {
+				e, ok := err.(*specerror.Error)
+				if ok && e.Err.Level < complianceLevel {
+					logrus.Warn(e)
+					continue
+				}
+				validationErrors = multierror.Append(validationErrors, err)
+			}
+			return validationErrors
 		}
 		fmt.Println("Bundle validation succeeded.")
 		return nil

--- a/man/oci-runtime-tool.1.md
+++ b/man/oci-runtime-tool.1.md
@@ -33,7 +33,8 @@ oci-runtime-tool is a collection of tools for working with the [OCI runtime spec
   Log level (panic, fatal, error, warn, info, or debug) (default: "error").
 
 **--compliance-level**=LEVEL
-  Compliance level (may, should or must) (default: "must").
+  Compliance level (`may`, `should`, or `must`) (default: `must`).
+  For example, a SHOULD-level violation is fatal if `--compliance-level` is `may` or `should` but non-fatal if `--compliance-level` is `must`.
 
 **-v**, **--version**
   Print version information.


### PR DESCRIPTION
The man-page entry and Bash completions for this option were added in 4029999d (#354), but the option was left unimplemented.  The implementation in this commit is very similar to the existing runtimetest implementation from 4029999d, except we warn instead of silently skipping non-fatal spec violations (more on that [here][1]).

The warning (vs. error) on invalid level arguments follows the runtimetest implementation from 6316a4e0 (#354).  I'd personally prefer hard errors on invalid level arguments, but didn't want to break runtime-tools consistency over that.

[1]: https://github.com/opencontainers/runtime-tools/pull/354#discussion_r110955465
