### PR TITLE
runtimetest: Raise ConfigInRootBundleDir for missing config.json

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -68,7 +68,7 @@ func loadSpecConfig(path string) (spec *rspec.Spec, err error) {
 	cf, err := os.Open(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%s not found", specConfig)
+			return nil, specerror.NewError(specerror.ConfigInRootBundleDir, err, rspec.Version)
 		}
 
 		return nil, err


### PR DESCRIPTION
This is a bit tricky, because before we load the config, we don't know the target spec version.  If a future spec version relaxes the current requirement, we'll have adjust runtimetest to tell it what version it's testing (where I've currently hard-coded 1.0.0).