### PR TITLE
runtimetest: Make validateRlimits silent on Windows

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -267,12 +267,11 @@ func validateHostname(spec *rspec.Spec) error {
 }
 
 func validateRlimits(spec *rspec.Spec) error {
-	if spec.Process == nil {
+	if runtime.GOOS == "windows" {
 		return nil
 	}
 
-	if runtime.GOOS != "linux" && runtime.GOOS != "solaris" {
-		logrus.Warnf("process.rlimits validation not yet implemented for OS %q", runtime.GOOS)
+	if spec.Process == nil {
 		return nil
 	}
 


### PR DESCRIPTION
This isn't a question of not being implemented yet.  Windows [does not, and is unlikely to ever, support rlimits][1].  And the spec [only defines `process.rlimits` for POSIX platforms][2].  Folks writing Windows configs will only be setting `process.rlimits` as an out-of-spec extention.  We, as runtime validators, are unlikely to write such configs.  But if we use `runtimetest` in a container launched from such a config, we should silently ignore that out-of-spec extention, just like we silently ignore all other out-of-spec extentions, instead of logging a warning.

Previous discussion of this issue in the config-validation context [here][3].

[1]: https://github.com/opencontainers/runtime-spec/pull/835#issuecomment-303455386
[2]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md#posix-process
[3]: https://github.com/opencontainers/runtime-tools/pull/481/files#r143615390