### PR TITLE
support json value for hooks

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -305,15 +305,9 @@ _oci-runtime-tool_generate() {
 		--args
 		--env
 		--env-file
-		--hooks-poststart
-		--hooks-poststart-env
-		--hooks-poststart-timeout
-		--hooks-poststop
-		--hooks-poststop-env
-		--hooks-poststop-timeout
-		--hooks-prestart
-		--hooks-prestart-env
-		--hooks-prestart-timeout
+		--hooks-poststart-add
+		--hooks-poststop-add
+		--hooks-prestart-add
 		--hostname
 		--label
 		--linux-apparmor
@@ -387,6 +381,9 @@ _oci-runtime-tool_generate() {
 
 	local boolean_options="
 		--help -h
+		--hooks-poststart-remove-all
+		--hooks-poststop-remove-all
+		--hooks-prestart-remove-all
 		--linux-device-remove-all
 		--linux-disable-oom-kill
 		--linux-namespace-remove-all
@@ -415,7 +412,7 @@ _oci-runtime-tool_generate() {
 			return
 			;;
 
-		--hooks-poststart|--hooks-poststop|--hooks-prestart)
+		--hooks-poststart-add|--hooks-poststop-add|--hooks-prestart-add)
 			COMPREPLY=( $( compgen -W "$( __oci-runtime-tool_hooks )" -- "$cur" ) )
 			__oci-runtime-tool_nospace
 			return

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -743,42 +743,21 @@ func (g *Generator) ClearPreStartHooks() {
 }
 
 // AddPreStartHook add a prestart hook into g.spec.Hooks.Prestart.
-func (g *Generator) AddPreStartHook(path string, args []string) {
+func (g *Generator) AddPreStartHook(hookObject string) error {
 	g.initSpecHooks()
-	hook := rspec.Hook{Path: path, Args: args}
+	tmpHook := rspec.Hook{}
+	err := json.Unmarshal([]byte(hookObject), &tmpHook)
+	if err != nil {
+		return err
+	}
 	for i, hook := range g.spec.Hooks.Prestart {
-		if hook.Path == path {
-			g.spec.Hooks.Prestart[i] = hook
-			return
+		if hook.Path == tmpHook.Path {
+			g.spec.Hooks.Prestart[i] = tmpHook
+			return nil
 		}
 	}
-	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, hook)
-}
-
-// AddPreStartHookEnv adds envs of a prestart hook into g.spec.Hooks.Prestart.
-func (g *Generator) AddPreStartHookEnv(path string, envs []string) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Prestart {
-		if hook.Path == path {
-			g.spec.Hooks.Prestart[i].Env = envs
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Env: envs}
-	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, hook)
-}
-
-// AddPreStartHookTimeout adds timeout of a prestart hook into g.spec.Hooks.Prestart.
-func (g *Generator) AddPreStartHookTimeout(path string, timeout int) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Prestart {
-		if hook.Path == path {
-			g.spec.Hooks.Prestart[i].Timeout = &timeout
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Timeout: &timeout}
-	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, hook)
+	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, tmpHook)
+	return nil
 }
 
 // ClearPostStopHooks clear g.spec.Hooks.Poststop.
@@ -790,42 +769,21 @@ func (g *Generator) ClearPostStopHooks() {
 }
 
 // AddPostStopHook adds a poststop hook into g.spec.Hooks.Poststop.
-func (g *Generator) AddPostStopHook(path string, args []string) {
+func (g *Generator) AddPostStopHook(hookObject string) error {
 	g.initSpecHooks()
-	hook := rspec.Hook{Path: path, Args: args}
+	tmpHook := rspec.Hook{}
+	err := json.Unmarshal([]byte(hookObject), &tmpHook)
+	if err != nil {
+		return err
+	}
 	for i, hook := range g.spec.Hooks.Poststop {
-		if hook.Path == path {
-			g.spec.Hooks.Poststop[i] = hook
-			return
+		if hook.Path == tmpHook.Path {
+			g.spec.Hooks.Poststop[i] = tmpHook
+			return nil
 		}
 	}
-	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, hook)
-}
-
-// AddPostStopHookEnv adds envs of a poststop hook into g.spec.Hooks.Poststop.
-func (g *Generator) AddPostStopHookEnv(path string, envs []string) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Poststop {
-		if hook.Path == path {
-			g.spec.Hooks.Poststop[i].Env = envs
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Env: envs}
-	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, hook)
-}
-
-// AddPostStopHookTimeout adds timeout of a poststop hook into g.spec.Hooks.Poststop.
-func (g *Generator) AddPostStopHookTimeout(path string, timeout int) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Poststop {
-		if hook.Path == path {
-			g.spec.Hooks.Poststop[i].Timeout = &timeout
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Timeout: &timeout}
-	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, hook)
+	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, tmpHook)
+	return nil
 }
 
 // ClearPostStartHooks clear g.spec.Hooks.Poststart.
@@ -837,42 +795,21 @@ func (g *Generator) ClearPostStartHooks() {
 }
 
 // AddPostStartHook adds a poststart hook into g.spec.Hooks.Poststart.
-func (g *Generator) AddPostStartHook(path string, args []string) {
+func (g *Generator) AddPostStartHook(hookObject string) error {
 	g.initSpecHooks()
-	hook := rspec.Hook{Path: path, Args: args}
+	tmpHook := rspec.Hook{}
+	err := json.Unmarshal([]byte(hookObject), &tmpHook)
+	if err != nil {
+		return err
+	}
 	for i, hook := range g.spec.Hooks.Poststart {
-		if hook.Path == path {
-			g.spec.Hooks.Poststart[i] = hook
-			return
+		if hook.Path == tmpHook.Path {
+			g.spec.Hooks.Poststart[i] = tmpHook
+			return nil
 		}
 	}
-	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, hook)
-}
-
-// AddPostStartHookEnv adds envs of a poststart hook into g.spec.Hooks.Poststart.
-func (g *Generator) AddPostStartHookEnv(path string, envs []string) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Poststart {
-		if hook.Path == path {
-			g.spec.Hooks.Poststart[i].Env = envs
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Env: envs}
-	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, hook)
-}
-
-// AddPostStartHookTimeout adds timeout of a poststart hook into g.spec.Hooks.Poststart.
-func (g *Generator) AddPostStartHookTimeout(path string, timeout int) {
-	g.initSpecHooks()
-	for i, hook := range g.spec.Hooks.Poststart {
-		if hook.Path == path {
-			g.spec.Hooks.Poststart[i].Timeout = &timeout
-			return
-		}
-	}
-	hook := rspec.Hook{Path: path, Timeout: &timeout}
-	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, hook)
+	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, tmpHook)
+	return nil
 }
 
 // AddTmpfsMount adds a tmpfs mount into g.spec.Mounts.

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -41,45 +41,51 @@ read the configuration from `config.json`.
 **--hostname**=""
   Set the container host name that is available inside the container.
 
-**--hooks-poststart**=CMD[:ARGS...]
+**--hooks-poststart-add**=[]
   Set command to run in poststart hooks. Can be specified multiple times.
   The multiple commands will be run in order before the container process
   gets launched but after the container environment and main process has been
   created.
 
-**--hooks-poststart-env**=[]
-  Set environment variables for commands in poststart hooks, format is CMD:ENV. e.g. --hooks-poststart-env=/bin/test:key=value
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  --hooks-poststart-add '{"path":"/bin/test","args":["a1","b2"],"timeout":5}'
 
-**--hooks-poststart-timeout**=[]
-  Set timeout for commands in poststart hooks, format is CMD:TIMEOUT. e.g. --hooks-poststart-timeout=/bin/test:5
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  When same path specified over once, the last one make sense. So, you can
+  take advantage of this to modify existing poststart hooks.
 
-**--hooks-poststop**=CMD[:ARGS...]
+**--hooks-poststart-remove-all**=true|false
+  Remove all poststart hooks. The default is *false*.
+  When specifed with --hooks-poststart-add, will be applied first and then add
+  new poststart hooks.
+
+**--hooks-poststop-add**=[]
   Set command to run in poststop hooks. Can be specified multiple times.
   The multiple commands will be run in order after the container process
   is stopped.
 
-**--hook-poststop-env**=[]
-  Set environment variables for commands in poststop hooks, format is CMD:ENV. e.g. --hooks-poststop-env=/bin/test:key=value
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  --hooks-poststop-add '{"path":"/bin/test","env":["a=b","c=d"],"timeout":5}'
 
-**--hooks-poststop-timeout**=[]
-  Set timeout for commands in poststop hooks, format is CMD:TIMEOUT. e.g. --hooks-poststop-timeout=/bin/test:5
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  When same path specified over once, the last one make sense. So, you can
+  take advantage of this to modify existing poststop hooks.
 
-**--hooks-prestart**=CMD[:ARGS...]
+**--hooks-poststop-remove-all**=true|false
+  Remove all poststop hooks. The default is *false*.
+  When specifed with --hooks-postop-add, will be applied first and then add
+  new poststop hooks.
+
+**--hooks-prestart-add**=[]
   Set command to run in prestart hooks. Can be specified multiple times.
   The multiple commands will be run in order after the container process
   has been created but before it executes the user-configured code.
 
-**--hooks-prestart-env**=[]
-  Set environment variables for commands in prestart hooks, format is CMD:ENV. e.g. --hooks-prestart-env=/bin/test:key=value
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  --hooks-prestart-add '{"path":"/bin/test"}'
 
-**--hooks-prestart-timeout**=[]
-  Set timeout for commands in prestart hooks, format is CMD:TIMEOUT. e.g. --hooks-prestart-timeout=/bin/test:5
-  This option can be specified multiple times. When same CMD specified over once, the last one make sense.
+  When same path specified over once, the last one make sense. So, you can
+  take advantage of this to modify existing prestart hooks.
+
+**--hooks-prestart-remove-all**=true|false
+  Remove all prestart hooks. The default is *false*.
+  When specifed with --hooks-prestart-add, will be applied first and then add
+  new prestart hooks.
 
 **--label**=[]
   Add annotations to the configuration e.g. key=value.


### PR DESCRIPTION
As discussed in #470, there is not suitable separators for hooks.
Because of path may contains them.
So, decide to support json value for hooks.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>