### PR TITLE
validate: remove duplicate verification

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -597,8 +597,8 @@ func (v *Validator) CheckLinux() (errs error) {
 
 	for index := 0; index < len(v.spec.Linux.Namespaces); index++ {
 		ns := v.spec.Linux.Namespaces[index]
-		if !v.namespaceValid(ns) {
-			errs = multierror.Append(errs, fmt.Errorf("namespace %v is invalid", ns))
+		if ns.Path != "" && !osFilepath.IsAbs(v.platform, ns.Path) {
+			errs = multierror.Append(errs, specerror.NewError(specerror.NSPathAbs, fmt.Errorf("namespace.path %q is not an absolute path", ns.Path), rspec.Version))
 		}
 
 		tmpItem := nsTypeList[ns.Type]
@@ -738,10 +738,6 @@ func (v *Validator) CheckLinux() (errs error) {
 		errs = multierror.Append(errs, v.CheckLinuxResources())
 	}
 
-	if v.spec.Linux.Seccomp != nil {
-		errs = multierror.Append(errs, v.CheckSeccomp())
-	}
-
 	for _, maskedPath := range v.spec.Linux.MaskedPaths {
 		if !strings.HasPrefix(maskedPath, "/") {
 			errs = multierror.Append(errs,
@@ -813,47 +809,6 @@ func (v *Validator) CheckLinuxResources() (errs error) {
 				errs = multierror.Append(errs, fmt.Errorf("access %s is invalid", r.Devices[index].Access))
 				return
 			}
-		}
-	}
-
-	return
-}
-
-// CheckSeccomp checkc v.spec.Linux.Seccomp
-func (v *Validator) CheckSeccomp() (errs error) {
-	logrus.Debugf("check linux seccomp")
-
-	s := v.spec.Linux.Seccomp
-	if !seccompActionValid(s.DefaultAction) {
-		errs = multierror.Append(errs, fmt.Errorf("seccomp defaultAction %q is invalid", s.DefaultAction))
-	}
-	for index := 0; index < len(s.Syscalls); index++ {
-		if !syscallValid(s.Syscalls[index]) {
-			errs = multierror.Append(errs, fmt.Errorf("syscall %v is invalid", s.Syscalls[index]))
-		}
-	}
-	for index := 0; index < len(s.Architectures); index++ {
-		switch s.Architectures[index] {
-		case rspec.ArchX86:
-		case rspec.ArchX86_64:
-		case rspec.ArchX32:
-		case rspec.ArchARM:
-		case rspec.ArchAARCH64:
-		case rspec.ArchMIPS:
-		case rspec.ArchMIPS64:
-		case rspec.ArchMIPS64N32:
-		case rspec.ArchMIPSEL:
-		case rspec.ArchMIPSEL64:
-		case rspec.ArchMIPSEL64N32:
-		case rspec.ArchPPC:
-		case rspec.ArchPPC64:
-		case rspec.ArchPPC64LE:
-		case rspec.ArchS390:
-		case rspec.ArchS390X:
-		case rspec.ArchPARISC:
-		case rspec.ArchPARISC64:
-		default:
-			errs = multierror.Append(errs, fmt.Errorf("seccomp architecture %q is invalid", s.Architectures[index]))
 		}
 	}
 
@@ -936,26 +891,6 @@ func (v *Validator) rlimitValid(rlimit rspec.POSIXRlimit) (errs error) {
 	return
 }
 
-func (v *Validator) namespaceValid(ns rspec.LinuxNamespace) bool {
-	switch ns.Type {
-	case rspec.PIDNamespace:
-	case rspec.NetworkNamespace:
-	case rspec.MountNamespace:
-	case rspec.IPCNamespace:
-	case rspec.UTSNamespace:
-	case rspec.UserNamespace:
-	case rspec.CgroupNamespace:
-	default:
-		return false
-	}
-
-	if ns.Path != "" && !osFilepath.IsAbs(v.platform, ns.Path) {
-		return false
-	}
-
-	return true
-}
-
 func deviceValid(d rspec.LinuxDevice) bool {
 	switch d.Type {
 	case "b", "c", "u":
@@ -968,40 +903,6 @@ func deviceValid(d rspec.LinuxDevice) bool {
 		}
 	default:
 		return false
-	}
-	return true
-}
-
-func seccompActionValid(secc rspec.LinuxSeccompAction) bool {
-	switch secc {
-	case rspec.ActKill:
-	case rspec.ActTrap:
-	case rspec.ActErrno:
-	case rspec.ActTrace:
-	case rspec.ActAllow:
-	default:
-		return false
-	}
-	return true
-}
-
-func syscallValid(s rspec.LinuxSyscall) bool {
-	if !seccompActionValid(s.Action) {
-		return false
-	}
-	for index := 0; index < len(s.Args); index++ {
-		arg := s.Args[index]
-		switch arg.Op {
-		case rspec.OpNotEqual:
-		case rspec.OpLessThan:
-		case rspec.OpLessEqual:
-		case rspec.OpEqualTo:
-		case rspec.OpGreaterEqual:
-		case rspec.OpGreaterThan:
-		case rspec.OpMaskedEqual:
-		default:
-			return false
-		}
 	}
 	return true
 }


### PR DESCRIPTION
These fields have already been verified in `CheckJSONSchema`, so there is no need to verify again.
Avoid the following duplicate error message:

```
2 errors occurred:

* linux.seccomp.architectures.2: linux.seccomp.architectures.2 must be one of the following: "SCMP_ARCH_X86", "SCMP_ARCH_X86_64", "SCMP_ARCH_X32", "SCMP_ARCH_ARM", "SCMP_ARCH_AARCH64", "SCMP_ARCH_MIPS", "SCMP_ARCH_MIPS64", "SCMP_ARCH_MIPS64N32", "SCMP_ARCH_MIPSEL", "SCMP_ARCH_MIPSEL64", "SCMP_ARCH_MIPSEL64N32", "SCMP_ARCH_PPC", "SCMP_ARCH_PPC64", "SCMP_ARCH_PPC64LE", "SCMP_ARCH_S390", "SCMP_ARCH_S390X", "SCMP_ARCH_PARISC", "SCMP_ARCH_PARISC64"
* seccomp architecture "SCMP_ACH_X32" is invalid

```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>