### PR TITLE
filepath: fix the Abs error under Windows

### DIFF
--- a/filepath/abs.go
+++ b/filepath/abs.go
@@ -1,7 +1,6 @@
 package filepath
 
 import (
-	"errors"
 	"regexp"
 	"strings"
 )
@@ -11,9 +10,6 @@ var windowsAbs = regexp.MustCompile(`^[a-zA-Z]:\\.*$`)
 // Abs is a version of path/filepath's Abs with an explicit operating
 // system and current working directory.
 func Abs(os, path, cwd string) (_ string, err error) {
-	if os == "windows" {
-		return "", errors.New("Abs() does not support windows yet")
-	}
 	if IsAbs(os, path) {
 		return Clean(os, path), nil
 	}

--- a/filepath/clean.go
+++ b/filepath/clean.go
@@ -46,7 +46,7 @@ func Clean(os, path string) string {
 	}
 
 	cleaned := strings.Join(elements, string(sep))
-	if abs {
+	if abs && os == "linux" {
 		cleaned = fmt.Sprintf("%c%s", sep, cleaned)
 	}
 	if cleaned == path {


### PR DESCRIPTION
Fix the following error when `os` is `Windows`, can‘t judge `mount.Destination`.

```
./oci-runtime-tool validate --platform windows
2 errors occurred:

* Abs() does not support windows yet
* Abs() does not support windows yet
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>