### PR TITLE
validate_test: add test func

### DIFF
--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -414,3 +414,41 @@ func TestCheckLinux(t *testing.T) {
 		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), fmt.Sprintf("failed CheckLinux: %v %d", err, c.expected))
 	}
 }
+
+func TestCheckPlatform(t *testing.T) {
+	cases := []struct {
+		val      rspec.Spec
+		platform string
+		expected specerror.Code
+	}{
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+			},
+			platform: "linux",
+			expected: specerror.NonError,
+		},
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+			},
+			platform: "windows",
+			expected: specerror.PlatformSpecConfOnWindowsSet,
+		},
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+				Windows: &rspec.Windows{
+					LayerFolders: []string{"C:\\Layers\\layer1"},
+				},
+			},
+			platform: "windows",
+			expected: specerror.NonError,
+		},
+	}
+	for _, c := range cases {
+		v := NewValidator(&c.val, ".", false, c.platform)
+		err := v.CheckPlatform()
+		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), fmt.Sprintf("failed CheckPlatform: %v %d", err, c.expected))
+	}
+}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -452,3 +452,42 @@ func TestCheckPlatform(t *testing.T) {
 		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), fmt.Sprintf("failed CheckPlatform: %v %d", err, c.expected))
 	}
 }
+
+func TestCheckHooks(t *testing.T) {
+	cases := []struct {
+		val      rspec.Spec
+		expected specerror.Code
+	}{
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+				Hooks: &rspec.Hooks{
+					Prestart: []rspec.Hook{
+						{
+							Path: "/usr/bin/fix-mounts",
+						},
+					},
+				},
+			},
+			expected: specerror.NonError,
+		},
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+				Hooks: &rspec.Hooks{
+					Prestart: []rspec.Hook{
+						{
+							Path: "usr",
+						},
+					},
+				},
+			},
+			expected: specerror.PosixHooksPathAbs,
+		},
+	}
+	for _, c := range cases {
+		v := NewValidator(&c.val, ".", false, "linux")
+		err := v.CheckHooks()
+		assert.Equal(t, c.expected, specerror.FindError(err, c.expected), fmt.Sprintf("failed CheckHooks: %v %d", err, c.expected))
+	}
+}


### PR DESCRIPTION
There are some waiting improvements for the validation of the `mounts`, and the test function can be added later.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>