### PR TITLE
validate: modify the non-conforming validation

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -264,6 +264,10 @@ func (v *Validator) CheckSemVer() (errs error) {
 func (v *Validator) CheckHooks() (errs error) {
 	logrus.Debugf("check hooks")
 
+	if v.platform == "windows" {
+		return
+	}
+
 	if v.spec.Hooks != nil {
 		errs = multierror.Append(errs, v.checkEventHooks("prestart", v.spec.Hooks.Prestart, v.HostSpecific))
 		errs = multierror.Append(errs, v.checkEventHooks("poststart", v.spec.Hooks.Poststart, v.HostSpecific))


### PR DESCRIPTION
1.Capabilities only support linux-based systems, so verification functions should not be called on other systems.

2.Hooks only support  POSIX platforms.

3.add a double guards to the call of the verification function
* Internally, raise an error if you call a check function for a platform that doesn't define the checked property 
* Externally, only call check functions on the appropriate platforms.


Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>