### PR TITLE
validation/linux_cgroups_*: Generate TAP output (and outside-validation cleanup)

### DIFF
--- a/validation/linux_cgroups_blkio.go
+++ b/validation/linux_cgroups_blkio.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -22,12 +23,12 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lbd, err := cg.GetBlockIOData(pid, path)
+		lbd, err := cg.GetBlockIOData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_blkio.go
+++ b/validation/linux_cgroups_blkio.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -23,93 +20,7 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lbd, err := cg.GetBlockIOData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if *lbd.Weight != weight {
-			return fmt.Errorf("blkio weight is not set correctly, expect: %d, actual: %d", weight, lbd.Weight)
-		}
-		if *lbd.LeafWeight != leafWeight {
-			return fmt.Errorf("blkio leafWeight is not set correctly, expect: %d, actual: %d", weight, lbd.LeafWeight)
-		}
-
-		found := false
-		for _, wd := range lbd.WeightDevice {
-			if wd.Major == major && wd.Minor == minor {
-				found = true
-				if *wd.Weight != weight {
-					return fmt.Errorf("blkio weight for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, weight, wd.Weight)
-				}
-				if *wd.LeafWeight != leafWeight {
-					return fmt.Errorf("blkio leafWeight for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, leafWeight, wd.LeafWeight)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio weightDevice for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, trbd := range lbd.ThrottleReadBpsDevice {
-			if trbd.Major == major && trbd.Minor == minor {
-				found = true
-				if trbd.Rate != rate {
-					return fmt.Errorf("blkio read bps for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, trbd.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio read bps for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, twbd := range lbd.ThrottleWriteBpsDevice {
-			if twbd.Major == major && twbd.Minor == minor {
-				found = true
-				if twbd.Rate != rate {
-					return fmt.Errorf("blkio write bps for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, twbd.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio write bps for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, trid := range lbd.ThrottleReadIOPSDevice {
-			if trid.Major == major && trid.Minor == minor {
-				found = true
-				if trid.Rate != rate {
-					return fmt.Errorf("blkio read iops for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, trid.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio read iops for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, twid := range lbd.ThrottleWriteIOPSDevice {
-			if twid.Major == major && twid.Minor == minor {
-				found = true
-				if twid.Rate != rate {
-					return fmt.Errorf("blkio write iops for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, twid.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio write iops for %d:%d is not set", major, minor)
-		}
-
-		return nil
-	})
-
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -19,12 +20,12 @@ func main() {
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lcd, err := cg.GetCPUData(pid, path)
+		lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,12 +14,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lhd, err := cg.GetHugepageLimitData(pid, path)
+		lhd, err := cg.GetHugepageLimitData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_memory.go
+++ b/validation/linux_cgroups_memory.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -20,38 +17,7 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lm, err := cg.GetMemoryData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if limit != *lm.Limit {
-			return fmt.Errorf("memory limit is not set correctly, expect: %d, actual: %d", limit, *lm.Limit)
-		}
-		if limit != *lm.Reservation {
-			return fmt.Errorf("memory reservation is not set correctly, expect: %d, actual: %d", limit, *lm.Reservation)
-		}
-		if limit != *lm.Swap {
-			return fmt.Errorf("memory swap is not set correctly, expect: %d, actual: %d", limit, *lm.Reservation)
-		}
-		if limit != *lm.Kernel {
-			return fmt.Errorf("memory kernel is not set correctly, expect: %d, actual: %d", limit, *lm.Kernel)
-		}
-		if limit != *lm.KernelTCP {
-			return fmt.Errorf("memory kernelTCP is not set correctly, expect: %d, actual: %d", limit, *lm.Kernel)
-		}
-		if swappiness != *lm.Swappiness {
-			return fmt.Errorf("memory swappiness is not set correctly, expect: %d, actual: %d", swappiness, *lm.Swappiness)
-		}
-		if true != *lm.DisableOOMKiller {
-			return fmt.Errorf("memory oom is not set correctly, expect: %t, actual: %t", true, *lm.DisableOOMKiller)
-		}
-		return nil
-	})
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_memory.go
+++ b/validation/linux_cgroups_memory.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -19,12 +20,12 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lm, err := cg.GetMemoryData(pid, path)
+		lm, err := cg.GetMemoryData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_network.go
+++ b/validation/linux_cgroups_network.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -14,34 +11,8 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lnd, err := cg.GetNetworkData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if *lnd.ClassID != id {
-			return fmt.Errorf("network ID is not set correctly, expect: %d, actual: %d", id, lnd.ClassID)
-		}
-		found := false
-		for _, lip := range lnd.Priorities {
-			if lip.Name == ifName {
-				found = true
-				if lip.Priority != prio {
-					return fmt.Errorf("network priority for %s is not set correctly, expect: %d, actual: %d", ifName, prio, lip.Priority)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("network priority for %s is not set correctly", ifName)
-		}
-
-		return nil
-	})
-
+	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_network.go
+++ b/validation/linux_cgroups_network.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,12 +14,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lnd, err := cg.GetNetworkData(pid, path)
+		lnd, err := cg.GetNetworkData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_pids.go
+++ b/validation/linux_cgroups_pids.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -12,12 +13,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, cgroups.AbsCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lpd, err := cg.GetPidsData(pid, path)
+		lpd, err := cg.GetPidsData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_pids.go
+++ b/validation/linux_cgroups_pids.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,21 +10,7 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lpd, err := cg.GetPidsData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if lpd.Limit != limit {
-			return fmt.Errorf("pids limit is not set correctly, expect: %d, actual: %d", limit, lpd.Limit)
-		}
-		return nil
-	})
-
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_blkio.go
+++ b/validation/linux_cgroups_relative_blkio.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -22,12 +23,12 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lbd, err := cg.GetBlockIOData(pid, path)
+		lbd, err := cg.GetBlockIOData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_blkio.go
+++ b/validation/linux_cgroups_relative_blkio.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -23,92 +20,7 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lbd, err := cg.GetBlockIOData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if *lbd.Weight != weight {
-			return fmt.Errorf("blkio weight is not set correctly, expect: %d, actual: %d", weight, lbd.Weight)
-		}
-		if *lbd.LeafWeight != leafWeight {
-			return fmt.Errorf("blkio leafWeight is not set correctly, expect: %d, actual: %d", weight, lbd.LeafWeight)
-		}
-
-		found := false
-		for _, wd := range lbd.WeightDevice {
-			if wd.Major == major && wd.Minor == minor {
-				found = true
-				if *wd.Weight != weight {
-					return fmt.Errorf("blkio weight for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, weight, wd.Weight)
-				}
-				if *wd.LeafWeight != leafWeight {
-					return fmt.Errorf("blkio leafWeight for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, leafWeight, wd.LeafWeight)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio weightDevice for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, trbd := range lbd.ThrottleReadBpsDevice {
-			if trbd.Major == major && trbd.Minor == minor {
-				found = true
-				if trbd.Rate != rate {
-					return fmt.Errorf("blkio read bps for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, trbd.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio read bps for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, twbd := range lbd.ThrottleWriteBpsDevice {
-			if twbd.Major == major && twbd.Minor == minor {
-				found = true
-				if twbd.Rate != rate {
-					return fmt.Errorf("blkio write bps for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, twbd.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio write bps for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, trid := range lbd.ThrottleReadIOPSDevice {
-			if trid.Major == major && trid.Minor == minor {
-				found = true
-				if trid.Rate != rate {
-					return fmt.Errorf("blkio read iops for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, trid.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio read iops for %d:%d is not set", major, minor)
-		}
-
-		found = false
-		for _, twid := range lbd.ThrottleWriteIOPSDevice {
-			if twid.Major == major && twid.Minor == minor {
-				found = true
-				if twid.Rate != rate {
-					return fmt.Errorf("blkio write iops for %d:%d is not set correctly, expect: %d, actual: %d", major, minor, rate, twid.Rate)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("blkio write iops for %d:%d is not set", major, minor)
-		}
-
-		return nil
-	})
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
 
 	if err != nil {
 		util.Fatal(err)

--- a/validation/linux_cgroups_relative_cpus.go
+++ b/validation/linux_cgroups_relative_cpus.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"fmt"
-
+	"github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
@@ -21,29 +20,41 @@ func main() {
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
 	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+		t := tap.New()
+		t.Header(0)
+
 		cg, err := cgroups.FindCgroup()
+		t.Ok((err == nil), "find cpus cgroup")
 		if err != nil {
-			return err
+			t.Diagnostic(err.Error())
+			t.AutoPlan()
+			return nil
 		}
+
 		lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
+		t.Ok((err == nil), "get cpus cgroup data")
 		if err != nil {
-			return err
+			t.Diagnostic(err.Error())
+			t.AutoPlan()
+			return nil
 		}
-		if *lcd.Shares != shares {
-			return fmt.Errorf("cpus shares limit is not set correctly, expect: %d, actual: %d", shares, lcd.Shares)
-		}
-		if *lcd.Quota != quota {
-			return fmt.Errorf("cpus quota is not set correctly, expect: %d, actual: %d", quota, lcd.Quota)
-		}
-		if *lcd.Period != period {
-			return fmt.Errorf("cpus period is not set correctly, expect: %d, actual: %d", period, lcd.Period)
-		}
-		if lcd.Cpus != cpus {
-			return fmt.Errorf("cpus cpus is not set correctly, expect: %s, actual: %s", cpus, lcd.Cpus)
-		}
-		if lcd.Mems != mems {
-			return fmt.Errorf("cpus mems is not set correctly, expect: %s, actual: %s", mems, lcd.Mems)
-		}
+
+		t.Ok(*lcd.Shares == shares, "cpus shares limit is set correctly")
+		t.Diagnosticf("expect: %d, actual: %d", shares, lcd.Shares)
+
+		t.Ok(*lcd.Quota == quota, "cpus quota is set correctly")
+		t.Diagnosticf("expect: %d, actual: %d", quota, lcd.Quota)
+
+		t.Ok(*lcd.Period == period, "cpus period is set correctly")
+		t.Diagnosticf("expect: %d, actual: %d", period, lcd.Period)
+
+		t.Ok(lcd.Cpus == cpus, "cpus cpus is set correctly")
+		t.Diagnosticf("expect: %s, actual: %s", cpus, lcd.Cpus)
+
+		t.Ok(lcd.Mems == mems, "cpus mems is set correctly")
+		t.Diagnosticf("expect: %s, actual: %s", mems, lcd.Mems)
+
+		t.AutoPlan()
 		return nil
 	})
 

--- a/validation/linux_cgroups_relative_cpus.go
+++ b/validation/linux_cgroups_relative_cpus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -19,12 +20,12 @@ func main() {
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lcd, err := cg.GetCPUData(pid, path)
+		lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_hugetlb.go
+++ b/validation/linux_cgroups_relative_hugetlb.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,12 +14,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lhd, err := cg.GetHugepageLimitData(pid, path)
+		lhd, err := cg.GetHugepageLimitData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_hugetlb.go
+++ b/validation/linux_cgroups_relative_hugetlb.go
@@ -1,8 +1,7 @@
 package main
 
 import (
-	"fmt"
-
+	"github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
@@ -15,21 +14,39 @@ func main() {
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
 	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+		t := tap.New()
+		t.Header(0)
+
 		cg, err := cgroups.FindCgroup()
+		t.Ok((err == nil), "find hugetlb cgroup")
 		if err != nil {
-			return err
+			t.Diagnostic(err.Error())
+			t.AutoPlan()
+			return nil
 		}
+
 		lhd, err := cg.GetHugepageLimitData(state.Pid, config.Linux.CgroupsPath)
+		t.Ok((err == nil), "get hugetlb cgroup data")
 		if err != nil {
-			return err
+			t.Diagnostic(err.Error())
+			t.AutoPlan()
+			return nil
 		}
+
+		found := false
 		for _, lhl := range lhd {
-			if lhl.Pagesize == page && lhl.Limit != limit {
-				return fmt.Errorf("hugepage %s limit is not set correctly, expect: %d, actual: %d", page, limit, lhl.Limit)
+			if lhl.Pagesize == page {
+				found = true
+				t.Ok(lhl.Limit == limit, "hugepage limit is set correctly")
+				t.Diagnosticf("expect: %d, actual: %d", limit, lhl.Limit)
 			}
 		}
+		t.Ok(found, "hugepage limit found")
+
+		t.AutoPlan()
 		return nil
 	})
+
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_memory.go
+++ b/validation/linux_cgroups_relative_memory.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -20,38 +17,7 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lm, err := cg.GetMemoryData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if limit != *lm.Limit {
-			return fmt.Errorf("memory limit is not set correctly, expect: %d, actual: %d", limit, *lm.Limit)
-		}
-		if limit != *lm.Reservation {
-			return fmt.Errorf("memory reservation is not set correctly, expect: %d, actual: %d", limit, *lm.Reservation)
-		}
-		if limit != *lm.Swap {
-			return fmt.Errorf("memory swap is not set correctly, expect: %d, actual: %d", limit, *lm.Reservation)
-		}
-		if limit != *lm.Kernel {
-			return fmt.Errorf("memory kernel is not set correctly, expect: %d, actual: %d", limit, *lm.Kernel)
-		}
-		if limit != *lm.KernelTCP {
-			return fmt.Errorf("memory kernelTCP is not set correctly, expect: %d, actual: %d", limit, *lm.Kernel)
-		}
-		if swappiness != *lm.Swappiness {
-			return fmt.Errorf("memory swappiness is not set correctly, expect: %d, actual: %d", swappiness, *lm.Swappiness)
-		}
-		if true != *lm.DisableOOMKiller {
-			return fmt.Errorf("memory oom is not set correctly, expect: %t, actual: %t", true, *lm.DisableOOMKiller)
-		}
-		return nil
-	})
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_memory.go
+++ b/validation/linux_cgroups_relative_memory.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -19,12 +20,12 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lm, err := cg.GetMemoryData(pid, path)
+		lm, err := cg.GetMemoryData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_network.go
+++ b/validation/linux_cgroups_relative_network.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -14,34 +11,8 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lnd, err := cg.GetNetworkData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if *lnd.ClassID != id {
-			return fmt.Errorf("network ID is not set correctly, expect: %d, actual: %d", id, lnd.ClassID)
-		}
-		found := false
-		for _, lip := range lnd.Priorities {
-			if lip.Name == ifName {
-				found = true
-				if lip.Priority != prio {
-					return fmt.Errorf("network priority for %s is not set correctly, expect: %d, actual: %d", ifName, prio, lip.Priority)
-				}
-			}
-		}
-		if !found {
-			return fmt.Errorf("network priority for %s is not set correctly", ifName)
-		}
-
-		return nil
-	})
-
+	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_relative_network.go
+++ b/validation/linux_cgroups_relative_network.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,12 +14,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lnd, err := cg.GetNetworkData(pid, path)
+		lnd, err := cg.GetNetworkData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_pids.go
+++ b/validation/linux_cgroups_relative_pids.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -12,12 +13,12 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, cgroups.RelCgroupPath, func(pid int, path string) error {
+	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err
 		}
-		lpd, err := cg.GetPidsData(pid, path)
+		lpd, err := cg.GetPidsData(state.Pid, config.Linux.CgroupsPath)
 		if err != nil {
 			return err
 		}

--- a/validation/linux_cgroups_relative_pids.go
+++ b/validation/linux_cgroups_relative_pids.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -13,21 +10,7 @@ func main() {
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err := util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lpd, err := cg.GetPidsData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		if lpd.Limit != limit {
-			return fmt.Errorf("pids limit is not set correctly, expect: %d, actual: %d", limit, lpd.Limit)
-		}
-		return nil
-	})
-
+	err := util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/test-yaml
+++ b/validation/test-yaml
@@ -1,0 +1,7 @@
+#!/bin/sh
+cat <<EOF
+TAP version 13
+1..2
+not ok 1 - failing
+ok 2 # SKIP: skipping
+EOF

--- a/validation/util/linux_resources_blkio.go
+++ b/validation/util/linux_resources_blkio.go
@@ -1,0 +1,103 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+)
+
+// ValidateLinuxResourcesBlockIO validates linux.resources.blockIO.
+func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error {
+	t := tap.New()
+	t.Header(0)
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find blkio cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	lbd, err := cg.GetBlockIOData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get blkio cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	t.Ok(*lbd.Weight == *config.Linux.Resources.BlockIO.Weight, "blkio weight is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.Weight, lbd.Weight)
+
+	t.Ok(*lbd.LeafWeight == *config.Linux.Resources.BlockIO.LeafWeight, "blkio leafWeight is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.LeafWeight, lbd.LeafWeight)
+
+	for _, device := range config.Linux.Resources.BlockIO.WeightDevice {
+		found := false
+		for _, wd := range lbd.WeightDevice {
+			if wd.Major == device.Major && wd.Minor == device.Minor {
+				found = true
+				t.Ok(*wd.Weight == *device.Weight, fmt.Sprintf("blkio weight for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", *device.Weight, *wd.Weight)
+
+				t.Ok(*wd.LeafWeight != *device.LeafWeight, fmt.Sprintf("blkio leafWeight for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", *device.LeafWeight, *wd.LeafWeight)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("blkio weightDevice for %d:%d found", device.Major, device.Minor))
+	}
+
+	for _, device := range config.Linux.Resources.BlockIO.ThrottleReadBpsDevice {
+		found := false
+		for _, trbd := range lbd.ThrottleReadBpsDevice {
+			if trbd.Major == device.Major && trbd.Minor == device.Minor {
+				found = true
+				t.Ok(trbd.Rate == device.Rate, fmt.Sprintf("blkio read bps for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", device.Rate, trbd.Rate)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("blkio read bps for %d:%d found", device.Major, device.Minor))
+	}
+
+	for _, device := range config.Linux.Resources.BlockIO.ThrottleWriteBpsDevice {
+		found := false
+		for _, twbd := range lbd.ThrottleWriteBpsDevice {
+			if twbd.Major == device.Major && twbd.Minor == device.Minor {
+				found = true
+				t.Ok(twbd.Rate == device.Rate, fmt.Sprintf("blkio write bps for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", device.Rate, twbd.Rate)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("blkio write bps for %d:%d found", device.Major, device.Minor))
+	}
+
+	for _, device := range config.Linux.Resources.BlockIO.ThrottleReadIOPSDevice {
+		found := false
+		for _, trid := range lbd.ThrottleReadIOPSDevice {
+			if trid.Major == device.Major && trid.Minor == device.Minor {
+				found = true
+				t.Ok(trid.Rate == device.Rate, fmt.Sprintf("blkio read iops for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", device.Rate, trid.Rate)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("blkio read iops for %d:%d found", device.Major, device.Minor))
+	}
+
+	for _, device := range config.Linux.Resources.BlockIO.ThrottleWriteIOPSDevice {
+		found := false
+		for _, twid := range lbd.ThrottleWriteIOPSDevice {
+			if twid.Major == device.Major && twid.Minor == device.Minor {
+				found = true
+				t.Ok(twid.Rate == device.Rate, fmt.Sprintf("blkio write iops for %d:%d is set correctly", device.Major, device.Minor))
+				t.Diagnosticf("expect: %d, actual: %d", device.Rate, twid.Rate)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("blkio write iops for %d:%d found", device.Major, device.Minor))
+	}
+
+	t.AutoPlan()
+	return nil
+}

--- a/validation/util/linux_resources_memory.go
+++ b/validation/util/linux_resources_memory.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+)
+
+// ValidateLinuxResourcesMemory validates linux.resources.memory.
+func ValidateLinuxResourcesMemory(config *rspec.Spec, state *rspec.State) error {
+	t := tap.New()
+	t.Header(0)
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find memory cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	lm, err := cg.GetMemoryData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get memory cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	t.Ok(*lm.Limit == *config.Linux.Resources.Memory.Limit, "memory limit is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.Limit, *lm.Limit)
+
+	t.Ok(*lm.Reservation == *config.Linux.Resources.Memory.Reservation, "memory reservation is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.Reservation, *lm.Reservation)
+
+	t.Ok(*lm.Swap == *config.Linux.Resources.Memory.Swap, "memory swap is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.Swap, *lm.Reservation)
+
+	t.Ok(*lm.Kernel == *config.Linux.Resources.Memory.Kernel, "memory kernel is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.Kernel, *lm.Kernel)
+
+	t.Ok(*lm.KernelTCP == *config.Linux.Resources.Memory.KernelTCP, "memory kernelTCP is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.KernelTCP, *lm.Kernel)
+
+	t.Ok(*lm.Swappiness == *config.Linux.Resources.Memory.Swappiness, "memory swappiness is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Memory.Swappiness, *lm.Swappiness)
+
+	t.Ok(*lm.DisableOOMKiller == *config.Linux.Resources.Memory.DisableOOMKiller, "memory oom is set correctly")
+	t.Diagnosticf("expect: %t, actual: %t", *config.Linux.Resources.Memory.DisableOOMKiller, *lm.DisableOOMKiller)
+
+	t.AutoPlan()
+	return nil
+}

--- a/validation/util/linux_resources_network.go
+++ b/validation/util/linux_resources_network.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+)
+
+// ValidateLinuxResourcesNetwork validates linux.resources.network.
+func ValidateLinuxResourcesNetwork(config *rspec.Spec, state *rspec.State) error {
+	t := tap.New()
+	t.Header(0)
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find network cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	lnd, err := cg.GetNetworkData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get network cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	t.Ok(*lnd.ClassID == *config.Linux.Resources.Network.ClassID, "network ID set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Network.ClassID, lnd.ClassID)
+
+	for _, priority := range config.Linux.Resources.Network.Priorities {
+		found := false
+		for _, lip := range lnd.Priorities {
+			if lip.Name == priority.Name {
+				found = true
+				t.Ok(lip.Priority == priority.Priority, fmt.Sprintf("network priority for %s is set correctly", priority.Name))
+				t.Diagnosticf("expect: %d, actual: %d", priority.Priority, lip.Priority)
+			}
+		}
+		t.Ok(found, fmt.Sprintf("network priority for %s found", priority.Name))
+	}
+
+	t.AutoPlan()
+	return nil
+}

--- a/validation/util/linux_resources_pids.go
+++ b/validation/util/linux_resources_pids.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+)
+
+// ValidateLinuxResourcesPids validates linux.resources.pids.
+func ValidateLinuxResourcesPids(config *rspec.Spec, state *rspec.State) error {
+	t := tap.New()
+	t.Header(0)
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find pids cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	lpd, err := cg.GetPidsData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get pids cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	t.Ok(lpd.Limit == config.Linux.Resources.Pids.Limit, "pids limit is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", config.Linux.Resources.Pids.Limit, lpd.Limit)
+
+	t.AutoPlan()
+	return nil
+}

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mndrix/tap-go"
 	"github.com/mrunalp/fileutils"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/satori/go.uuid"
 )
@@ -25,7 +26,7 @@ var (
 type PreFunc func(string) error
 
 // AfterFunc validate container's outside environment after created
-type AfterFunc func(int, string) error
+type AfterFunc func(config *rspec.Spec, state *rspec.State) error
 
 func init() {
 	runtimeInEnv := os.Getenv("RUNTIME")
@@ -143,7 +144,7 @@ func RuntimeInsideValidate(g *generate.Generator, f PreFunc) (err error) {
 }
 
 // RuntimeOutsideValidate validate runtime outside a container.
-func RuntimeOutsideValidate(g *generate.Generator, cgroupPath string, f AfterFunc) error {
+func RuntimeOutsideValidate(g *generate.Generator, f AfterFunc) error {
 	bundleDir, err := PrepareBundle()
 	if err != nil {
 		return err
@@ -177,7 +178,7 @@ func RuntimeOutsideValidate(g *generate.Generator, cgroupPath string, f AfterFun
 		if err != nil {
 			return err
 		}
-		if err := f(state.Pid, cgroupPath); err != nil {
+		if err := f(g.Spec(), &state); err != nil {
 			return err
 		}
 	}

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -168,7 +168,7 @@ func RuntimeOutsideValidate(g *generate.Generator, f AfterFunc) error {
 	r.SetID(uuid.NewV4().String())
 	stderr, err := r.Create()
 	if err != nil {
-		os.Stderr.WriteString("failed to start the container\n")
+		os.Stderr.WriteString("failed to create the container\n")
 		os.Stderr.Write(stderr)
 		return err
 	}


### PR DESCRIPTION
The test harness requires TAP output.  Before this pull request:

```console
# RUNTIME=runc tap ./validation/linux_cgroups_pids.t
./validation/linux_cgroups_pids.t ..................... 0/1
  Skipped: 1
    ./validation/linux_cgroups_pids.t no tests found

total ................................................. 0/1

  0 passing (191.66ms)
  1 pending
```

After this pull request:

```console
# RUNTIME=runc tap ./validation/linux_cgroups_pids.t
./validation/linux_cgroups_pids.t ..................... 3/3
total ................................................. 3/3

  3 passing (185.118ms)

  ok
```

This pull request also:

* DRYs up some relative/absolute tests by factoring out the shared code into `util.ValidateLinuxResources*` helpers.
* Adds a missing `AddLinuxResourcesNetworkPriorities` call; previously we were testing for a priority that we hadn't actually configured.
* Fixes a `start` → `create` typo in an `RuntimeOutsideValidate` error message.
* Adjusts the `RuntimeOutsideValidate` to be generic; passing:
    * the full state object instead of just the PID, and
    * the full config object instead of just the cgroups path.

All of these are cleanups to the implementation which just landed via #93.