### PR TITLE
Recursive propagation flags should be legal to use

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -891,11 +891,15 @@ func (g *Generator) SetLinuxRootPropagation(rp string) error {
 	switch rp {
 	case "":
 	case "private":
+	case "rprivate":
 	case "slave":
+	case "rslave":
 	case "shared":
+	case "rshared":
 	case "unbindable":
+	case "runbindable":
 	default:
-		return fmt.Errorf("rootfs-propagation must be empty or one of private|slave|shared|unbindable")
+		return fmt.Errorf("rootfs-propagation %q must be empty or one of (r)private|(r)slave|(r)shared|(r)unbindable", rp)
 	}
 	g.initSpecLinux()
 	g.spec.Linux.RootfsPropagation = rp


### PR DESCRIPTION
Current root propagation code does not allow rslave, rshared, runbindable and rprivate.
These are all legal proagations and should be allowed.

Also added the "bad" propagation flag to the error to make diagnosis easier.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>