### PR TITLE
Add interface to remove mounts.

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -88,6 +88,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "linux-sysctl", Usage: "add sysctl settings e.g net.ipv4.forward=1"},
 	cli.StringSliceFlag{Name: "linux-uidmappings", Usage: "add UIDMappings e.g HostID:ContainerID:Size"},
 	cli.StringSliceFlag{Name: "mounts-add", Usage: "configures additional mounts inside container"},
+	cli.StringSliceFlag{Name: "mounts-remove", Usage: "remove destination mountpoints from inside container"},
 	cli.BoolFlag{Name: "mounts-remove-all", Usage: "remove all mounts inside container"},
 	cli.StringFlag{Name: "output", Usage: "output file (defaults to stdout)"},
 	cli.BoolFlag{Name: "privileged", Usage: "enable privileged container settings"},
@@ -430,6 +431,13 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 
 	if context.IsSet("mounts-remove-all") {
 		g.ClearMounts()
+	}
+
+	if context.IsSet("mounts-remove") {
+		mounts := context.StringSlice("mounts-remove")
+		for _, mount := range mounts {
+			g.RemoveMount(mount)
+		}
 	}
 
 	if context.IsSet("mounts-add") {

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -364,6 +364,7 @@ _oci-runtime-tool_generate() {
 		--linux-sysctl
 		--linux-uidmappings
 		--mounts-add
+		--mounts-remove
 		--output
 		--process-cap-add-ambient
 		--process-cap-add-bounding

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -988,6 +988,25 @@ func (g *Generator) AddMount(mnt rspec.Mount) {
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
 }
 
+// RemoveMount removes a mount point on the dest directory
+func (g *Generator) RemoveMount(dest string) {
+	g.initSpec()
+
+	for index, mount := range g.spec.Mounts {
+		if mount.Destination == dest {
+			g.spec.Mounts = append(g.spec.Mounts[:index], g.spec.Mounts[index+1:]...)
+			return
+		}
+	}
+}
+
+// Mounts returns the list of mounts
+func (g *Generator) Mounts() []rspec.Mount {
+	g.initSpec()
+
+	return g.spec.Mounts
+}
+
 // ClearMounts clear g.spec.Mounts
 func (g *Generator) ClearMounts() {
 	if g.spec == nil {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -54,3 +54,12 @@ func TestGenerateValid(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveMount(t *testing.T) {
+	g := generate.New()
+	size := len(g.Mounts())
+	g.RemoveMount("/dev/shm")
+	if size-1 != len(g.Mounts()) {
+		t.Errorf("Unable to remove /dev/shm from mounts")
+	}
+}

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -348,6 +348,10 @@ read the configuration from `config.json`.
   C. mount for windows platform
     --mount-add '{"destination": "C:\\folder-inside-container","source": "C:\\folder-on-host","options": ["ro"]}'
 
+**--mounts-remove**=[]
+  Remove mounts to destination path from inside container.
+  This option can be specified multiple times.
+
 **--mounts-remove-all**=true|false
   Remove all mounts inside the container. The default is *false*.
   When specified with --mount-add, this option will be parsed first.


### PR DESCRIPTION
We want to add a mount point to /dev/shm using the default spec,
but we don't want to mount /dev/shm via a tmpfs and then add our mountpoint
over it.

RemoveMount will remove a mount point based on the Destination, if it exists.
Does not return any error if the mount point does not exist.  Also added
Mounts() interface so that I could populate a test for new feature. Returns
the list of mounts.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>