### PR TITLE
AddMounts should be AddMount you are only adding a single Mount

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -427,8 +428,11 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("mounts-add") {
 		mounts := context.StringSlice("mounts-add")
 		for _, mount := range mounts {
-			err := g.AddMounts(mount)
-			if err != nil {
+			mnt := rspec.Mount{}
+			if err := json.Unmarshal([]byte(mount), &mnt); err != nil {
+				return err
+			}
+			if err := g.AddMount(mnt); err != nil {
 				return err
 			}
 		}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -980,15 +980,10 @@ func (g *Generator) AddPostStartHook(hookObject string) error {
 	return nil
 }
 
-// AddMounts adds a mount into g.spec.Mounts.
-func (g *Generator) AddMounts(mountObject string) error {
+// AddMount adds a mount into g.spec.Mounts.
+func (g *Generator) AddMount(mnt rspec.Mount) error {
 	g.initSpec()
 
-	mnt := rspec.Mount{}
-	err := json.Unmarshal([]byte(mountObject), &mnt)
-	if err != nil {
-		return err
-	}
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
 
 	return nil


### PR DESCRIPTION
AddMount should also take a rspec.Mount object rather then a json string.
We are using generate as a library not using the command line tool.
The tool should translate the json into a rspec.Mount.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>