### PR TITLE
Hooks should be passed in as rspec.Hook, not as a string.

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -466,8 +466,11 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("hooks-poststart-add") {
 		postStartHooks := context.StringSlice("hooks-poststart-add")
 		for _, hook := range postStartHooks {
-			err := g.AddPostStartHook(hook)
-			if err != nil {
+			tmpHook := rspec.Hook{}
+			if err := json.Unmarshal([]byte(hook), &tmpHook); err != nil {
+				return err
+			}
+			if err := g.AddPostStartHook(tmpHook); err != nil {
 				return err
 			}
 		}
@@ -480,8 +483,11 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("hooks-poststop-add") {
 		postStopHooks := context.StringSlice("hooks-poststop-add")
 		for _, hook := range postStopHooks {
-			err := g.AddPostStopHook(hook)
-			if err != nil {
+			tmpHook := rspec.Hook{}
+			if err := json.Unmarshal([]byte(hook), &tmpHook); err != nil {
+				return err
+			}
+			if err := g.AddPostStopHook(tmpHook); err != nil {
 				return err
 			}
 		}
@@ -494,8 +500,11 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	if context.IsSet("hooks-prestart-add") {
 		preStartHooks := context.StringSlice("hooks-prestart-add")
 		for _, hook := range preStartHooks {
-			err := g.AddPreStartHook(hook)
-			if err != nil {
+			tmpHook := rspec.Hook{}
+			if err := json.Unmarshal([]byte(hook), &tmpHook); err != nil {
+				return err
+			}
+			if err := g.AddPreStartHook(tmpHook); err != nil {
 				return err
 			}
 		}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -912,20 +912,15 @@ func (g *Generator) ClearPreStartHooks() {
 }
 
 // AddPreStartHook add a prestart hook into g.spec.Hooks.Prestart.
-func (g *Generator) AddPreStartHook(hookObject string) error {
+func (g *Generator) AddPreStartHook(preStartHook rspec.Hook) error {
 	g.initSpecHooks()
-	tmpHook := rspec.Hook{}
-	err := json.Unmarshal([]byte(hookObject), &tmpHook)
-	if err != nil {
-		return err
-	}
 	for i, hook := range g.spec.Hooks.Prestart {
-		if hook.Path == tmpHook.Path {
-			g.spec.Hooks.Prestart[i] = tmpHook
+		if hook.Path == preStartHook.Path {
+			g.spec.Hooks.Prestart[i] = preStartHook
 			return nil
 		}
 	}
-	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, tmpHook)
+	g.spec.Hooks.Prestart = append(g.spec.Hooks.Prestart, preStartHook)
 	return nil
 }
 
@@ -938,20 +933,15 @@ func (g *Generator) ClearPostStopHooks() {
 }
 
 // AddPostStopHook adds a poststop hook into g.spec.Hooks.Poststop.
-func (g *Generator) AddPostStopHook(hookObject string) error {
+func (g *Generator) AddPostStopHook(postStopHook rspec.Hook) error {
 	g.initSpecHooks()
-	tmpHook := rspec.Hook{}
-	err := json.Unmarshal([]byte(hookObject), &tmpHook)
-	if err != nil {
-		return err
-	}
 	for i, hook := range g.spec.Hooks.Poststop {
-		if hook.Path == tmpHook.Path {
-			g.spec.Hooks.Poststop[i] = tmpHook
+		if hook.Path == postStopHook.Path {
+			g.spec.Hooks.Poststop[i] = postStopHook
 			return nil
 		}
 	}
-	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, tmpHook)
+	g.spec.Hooks.Poststop = append(g.spec.Hooks.Poststop, postStopHook)
 	return nil
 }
 
@@ -964,20 +954,15 @@ func (g *Generator) ClearPostStartHooks() {
 }
 
 // AddPostStartHook adds a poststart hook into g.spec.Hooks.Poststart.
-func (g *Generator) AddPostStartHook(hookObject string) error {
+func (g *Generator) AddPostStartHook(postStartHook rspec.Hook) error {
 	g.initSpecHooks()
-	tmpHook := rspec.Hook{}
-	err := json.Unmarshal([]byte(hookObject), &tmpHook)
-	if err != nil {
-		return err
-	}
 	for i, hook := range g.spec.Hooks.Poststart {
-		if hook.Path == tmpHook.Path {
-			g.spec.Hooks.Poststart[i] = tmpHook
+		if hook.Path == postStartHook.Path {
+			g.spec.Hooks.Poststart[i] = postStartHook
 			return nil
 		}
 	}
-	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, tmpHook)
+	g.spec.Hooks.Poststart = append(g.spec.Hooks.Poststart, postStartHook)
 	return nil
 }
 


### PR DESCRIPTION
The marshalling should not be required to be used inside of the interface.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>