### PR TITLE
cmd/runtimetest/main: Run validateDefaultDevices even with process unset

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -507,13 +507,10 @@ func validateDefaultSymlinks(spec *rspec.Spec) error {
 }
 
 func validateDefaultDevices(spec *rspec.Spec) error {
-	if spec.Process == nil {
-		return nil
-	}
-
-	if spec.Process.Terminal {
+	if spec.Process != nil && spec.Process.Terminal {
 		defaultDevices = append(defaultDevices, "/dev/console")
 	}
+
 	for _, device := range defaultDevices {
 		fi, err := os.Stat(device)
 		if err != nil {


### PR DESCRIPTION
6d2dbbc9 (#494) put the nil-`Process` guard in, but it was a bit too coarse.  We can still run these tests with a nil `Process`, because all we need `Process` for is deciding whether or not to include `/dev/console`.