### PR TITLE
Relax LGTM requirement

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -9,7 +9,7 @@ always_pending:
   explanation: 'Work in progress...'
 
 group_defaults:
-  required: 2
+  required: 1
   approve_by_comment:
     enabled: true
     approve_regex: '^LGTM'


### PR DESCRIPTION
There has been a request to relax the number of LGTMs in the tools projects to help improve merge rate.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>