### PR TITLE
generate/seccomp: platform independent values

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -2,7 +2,6 @@ package seccomp
 
 import (
 	"runtime"
-	"syscall"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -513,7 +512,7 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				Args: []rspec.LinuxSeccompArg{
 					{
 						Index:    sysCloneFlagsIndex,
-						Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
+						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet,
 						ValueTwo: 0,
 						Op:       rspec.OpMaskedEqual,
 					},

--- a/generate/seccomp/seccomp_default_linux.go
+++ b/generate/seccomp/seccomp_default_linux.go
@@ -1,0 +1,15 @@
+// +build linux
+
+package seccomp
+
+import "syscall"
+
+// System values passed through on linux
+const (
+	CloneNewIPC  = syscall.CLONE_NEWIPC
+	CloneNewNet  = syscall.CLONE_NEWNET
+	CloneNewNS   = syscall.CLONE_NEWNS
+	CloneNewPID  = syscall.CLONE_NEWPID
+	CloneNewUser = syscall.CLONE_NEWUSER
+	CloneNewUTS  = syscall.CLONE_NEWUTS
+)

--- a/generate/seccomp/seccomp_default_unsupported.go
+++ b/generate/seccomp/seccomp_default_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package seccomp
+
+// These are copied from linux/amd64 syscall values, as a reference for other
+// platforms to have access to
+const (
+	CloneNewIPC    = 0x8000000
+	CloneNewNet    = 0x40000000
+	CloneNewNS     = 0x20000
+	CloneNewPID    = 0x20000000
+	CloneNewUser   = 0x10000000
+	CloneNewUTS    = 0x4000000
+	CloneNewCgroup = 0x02000000
+)


### PR DESCRIPTION
This default seccomp profile may need to be used/generated from
non-linux platforms, though the use of syscall package confines the
compile to linux only

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>