### PR TITLE
validation: Remove runc 'create' exit timing crutches

### DIFF
--- a/validation/pidfile.go
+++ b/validation/pidfile.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 
 	tap "github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/validation/util"
@@ -46,9 +45,6 @@ func main() {
 				return errors.New("Wrong pid in the pidfile")
 			}
 			return nil
-		},
-		PreDelete: func(r *util.Runtime) error {
-			return util.WaitingForStatus(*r, util.LifecycleStatusCreated, time.Second*10, time.Second*1)
 		},
 	}
 

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -183,11 +183,6 @@ func RuntimeInsideValidate(g *generate.Generator, f PreFunc) (err error) {
 		return err
 	}
 
-	// FIXME: why do we need this?  Without a sleep here, I get:
-	//   failed to start the container
-	//   container "..." does not exist
-	time.Sleep(1 * time.Second)
-
 	err = r.Start()
 	if err != nil {
 		os.Stderr.WriteString("failed to start the container\n")


### PR DESCRIPTION
The runtime-spec [defines a `creating` status][1] and requires the `create` operation to [finish][1] [creating][2] the container.  Our command line API also [requires the `create` command to block until creation completes][4]:

> Callers MAY block on this command's successful exit to trigger post-create activity.

runc [does not support `creating` yet][5], and it seems to return from `create` before having quite finished (or we wouldn't have needed the code I'm removing in this pull request).  However, both of those are runc problems.  These tests are about validating spec compliance, not about working around runc's issues, so remove the crutches.

I've opened opencontainers/runc#1703 and opencontainers/runc#1704 on the path to fixing both of these issues upstream in runc, but I don't think we need to wait for those to land before dropping the workarounds here.

[1]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/runtime.md#L19
[2]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/runtime.md#L54
[3]: https://github.com/opencontainers/runtime-spec/blame/v1.0.1/runtime.md#L101
[4]: https://github.com/opencontainers/runtime-tools/blame/7ac117af23fb7465142f16ac0d22277c9c82fefa/docs/command-line-interface.md#L79
[5]: https://github.com/opencontainers/runtime-tools/pull/557#discussion_r163762617