### PR TITLE
validate: add weightDevice validation

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -817,6 +817,18 @@ func (v *Validator) CheckLinuxResources() (errs error) {
 		}
 	}
 
+	if r.BlockIO != nil && r.BlockIO.WeightDevice != nil {
+		for _, weightDevice := range r.BlockIO.WeightDevice {
+			if weightDevice.Weight == nil && weightDevice.LeafWeight == nil {
+				errs = multierror.Append(errs,
+					specerror.NewError(
+						specerror.BlkIOWeightOrLeafWeightExist,
+						fmt.Errorf("You MUST specify at least one of `weight` or `leafWeight` in a given entry"),
+						rspec.Version))
+			}
+		}
+	}
+
 	return
 }
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -818,12 +818,12 @@ func (v *Validator) CheckLinuxResources() (errs error) {
 	}
 
 	if r.BlockIO != nil && r.BlockIO.WeightDevice != nil {
-		for _, weightDevice := range r.BlockIO.WeightDevice {
+		for i, weightDevice := range r.BlockIO.WeightDevice {
 			if weightDevice.Weight == nil && weightDevice.LeafWeight == nil {
 				errs = multierror.Append(errs,
 					specerror.NewError(
 						specerror.BlkIOWeightOrLeafWeightExist,
-						fmt.Errorf("You MUST specify at least one of `weight` or `leafWeight` in a given entry"),
+						fmt.Errorf("linux.resources.blockIO.weightDevice[%d] specifies neither weight nor leafWeight", i),
 						rspec.Version))
 			}
 		}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -485,6 +485,12 @@ func TestCheckProcess(t *testing.T) {
 }
 
 func TestCheckLinux(t *testing.T) {
+	weightDevices := []rspec.LinuxWeightDevice{
+		rspec.LinuxWeightDevice{},
+	}
+	weightDevices[0].Major = 5
+	weightDevices[0].Minor = 0
+
 	cases := []struct {
 		val      rspec.Spec
 		expected specerror.Code
@@ -556,6 +562,19 @@ func TestCheckLinux(t *testing.T) {
 				},
 			},
 			expected: specerror.ReadonlyPathsAbs,
+		},
+		{
+			val: rspec.Spec{
+				Version: "1.0.0",
+				Linux: &rspec.Linux{
+					Resources: &rspec.LinuxResources{
+						BlockIO: &rspec.LinuxBlockIO{
+							WeightDevice: weightDevices,
+						},
+					},
+				},
+			},
+			expected: specerror.BlkIOWeightOrLeafWeightExist,
 		},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
According to the following [specifications:](https://github.com/opencontainers/runtime-spec/blame/master/config-linux.md#L338)
``
You MUST specify at least one of weight or leafWeight in a given entry, and MAY specify both.
``

implement BlkIOWeightOrLeafWeightExist.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>