### PR TITLE
Fix condition in BlockIO test

### DIFF
--- a/validation/util/linux_resources_blkio.go
+++ b/validation/util/linux_resources_blkio.go
@@ -43,7 +43,7 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 				t.Ok(*wd.Weight == *device.Weight, fmt.Sprintf("blkio weight for %d:%d is set correctly", device.Major, device.Minor))
 				t.Diagnosticf("expect: %d, actual: %d", *device.Weight, *wd.Weight)
 
-				t.Ok(*wd.LeafWeight != *device.LeafWeight, fmt.Sprintf("blkio leafWeight for %d:%d is set correctly", device.Major, device.Minor))
+				t.Ok(*wd.LeafWeight == *device.LeafWeight, fmt.Sprintf("blkio leafWeight for %d:%d is set correctly", device.Major, device.Minor))
 				t.Diagnosticf("expect: %d, actual: %d", *device.LeafWeight, *wd.LeafWeight)
 			}
 		}


### PR DESCRIPTION
Symptoms:
```
$ sudo validation/linux_cgroups_relative_blkio.t

 not ok 6 - blkio leafWeight for 8:0 is set correctly
 # expect: 300, actual: 300
```

After the patch:
```
 ok 6 - blkio leafWeight for 8:0 is set correctly
 # expect: 300, actual: 300
```

Signed-off-by: Alban Crequy <alban@kinvolk.io>