### PR TITLE
runtimetest: fix uid_map parsing

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -632,11 +632,13 @@ func getIDMappings(path string) ([]rspec.LinuxIDMapping, error) {
 
 		idMap := strings.Fields(strings.TrimSpace(s.Text()))
 		if len(idMap) == 3 {
-			hostID, err := strconv.ParseUint(idMap[0], 0, 32)
+			// "man 7 user_namespaces" explains the format of uid_map and gid_map:
+			// <containerID> <hostID> <mapSize>
+			containerID, err := strconv.ParseUint(idMap[0], 0, 32)
 			if err != nil {
 				return nil, err
 			}
-			containerID, err := strconv.ParseUint(idMap[1], 0, 32)
+			hostID, err := strconv.ParseUint(idMap[1], 0, 32)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The fields of /proc/$pid/uid_map and /proc/$pid/gid_map were parsed in
the wrong order.

Related: https://github.com/opencontainers/runtime-spec/pull/956

Signed-off-by: Alban Crequy <alban@kinvolk.io>