### PR TITLE
validation: run CLI with correct argument order

### DIFF
--- a/validation/util/container.go
+++ b/validation/util/container.go
@@ -69,14 +69,14 @@ func (r *Runtime) SetID(id string) {
 func (r *Runtime) Create() (err error) {
 	var args []string
 	args = append(args, "create")
-	if r.ID != "" {
-		args = append(args, r.ID)
-	}
 	if r.PidFile != "" {
 		args = append(args, "--pid-file", r.PidFile)
 	}
 	if r.BundleDir != "" {
 		args = append(args, "--bundle", r.BundleDir)
+	}
+	if r.ID != "" {
+		args = append(args, r.ID)
 	}
 	cmd := exec.Command(r.RuntimeCommand, args...)
 	id := uuid.NewV4().String()


### PR DESCRIPTION
The OCI Runtime Command Line Interface [1][1] specifies the order of the
arguments:

```
$ funC [global-options] <COMMAND> [command-specific-options] <command-specific-arguments>
```

runc [2][2] is flexible whether command-specific-options is before or
after command-specific-arguments. But crun [3][3] is not, making the
tests fail. Since the CLI spec only specifies one order, the validation
tests should respect that order.

[1]: https://github.com/opencontainers/runtime-tools/blob/master/docs/command-line-interface.md#global-usage
[2]: https://github.com/opencontainers/runc
[3]: https://github.com/giuseppe/crun

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

/cc @giuseppe