### PR TITLE
Fix error messages in validation cgroup tests

### DIFF
--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -30,13 +30,13 @@ func main() {
 			return err
 		}
 		if *lcd.Shares != shares {
-			return fmt.Errorf("cpus shares limit is not set correctly, expect: %d, actual: %d", shares, lcd.Shares)
+			return fmt.Errorf("cpus shares limit is not set correctly, expect: %d, actual: %d", shares, *lcd.Shares)
 		}
 		if *lcd.Quota != quota {
-			return fmt.Errorf("cpus quota is not set correctly, expect: %d, actual: %d", quota, lcd.Quota)
+			return fmt.Errorf("cpus quota is not set correctly, expect: %d, actual: %d", quota, *lcd.Quota)
 		}
 		if *lcd.Period != period {
-			return fmt.Errorf("cpus period is not set correctly, expect: %d, actual: %d", period, lcd.Period)
+			return fmt.Errorf("cpus period is not set correctly, expect: %d, actual: %d", period, *lcd.Period)
 		}
 		if lcd.Cpus != cpus {
 			return fmt.Errorf("cpus cpus is not set correctly, expect: %s, actual: %s", cpus, lcd.Cpus)

--- a/validation/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	page := "1GB"
-	var limit uint64 = 56892210544640
+	var limit uint64 = 52985 * 1024 * 1024 * 1024 // multiple of hugepage size
 	g := util.GetDefaultGenerator()
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)

--- a/validation/util/linux_resources_blkio.go
+++ b/validation/util/linux_resources_blkio.go
@@ -30,10 +30,10 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 	}
 
 	t.Ok(*lbd.Weight == *config.Linux.Resources.BlockIO.Weight, "blkio weight is set correctly")
-	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.Weight, lbd.Weight)
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.Weight, *lbd.Weight)
 
 	t.Ok(*lbd.LeafWeight == *config.Linux.Resources.BlockIO.LeafWeight, "blkio leafWeight is set correctly")
-	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.LeafWeight, lbd.LeafWeight)
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.LeafWeight, *lbd.LeafWeight)
 
 	for _, device := range config.Linux.Resources.BlockIO.WeightDevice {
 		found := false

--- a/validation/util/linux_resources_network.go
+++ b/validation/util/linux_resources_network.go
@@ -30,7 +30,7 @@ func ValidateLinuxResourcesNetwork(config *rspec.Spec, state *rspec.State) error
 	}
 
 	t.Ok(*lnd.ClassID == *config.Linux.Resources.Network.ClassID, "network ID set correctly")
-	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Network.ClassID, lnd.ClassID)
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.Network.ClassID, *lnd.ClassID)
 
 	for _, priority := range config.Linux.Resources.Network.Priorities {
 		found := false


### PR DESCRIPTION
Symptoms:
```
 ok 3 - blkio weight is set correctly
 # expect: 500, actual: 842352267696
```

After the patch:
```
 ok 3 - blkio weight is set correctly
 # expect: 500, actual: 500
```

I found those issues by patching runc to introduce "off-by-one" bugs and
checking if they are correctly caught by the validation tests:
https://github.com/kinvolk/runc/commits/alban/off-by-one-bugs

Signed-off-by: Alban Crequy <alban@kinvolk.io>