### PR TITLE
contrib/rootfs-builder: Use $(cat rootfs-files)

### DIFF
--- a/contrib/rootfs-builder/Makefile
+++ b/contrib/rootfs-builder/Makefile
@@ -15,7 +15,7 @@ rootfs/%/bin/busybox: downloads/stage3-%-current.tar rootfs-files
 	sudo rm -rf rootfs/$*
 	sudo mkdir -p rootfs/$*
 	sudo tar -xvf downloads/stage3-$*-current.tar -C rootfs/$* \
-		--no-recursion --wildcards $$(< rootfs-files)
+		--no-recursion --wildcards $$(cat rootfs-files)
 	sudo touch $@
 
 .PRECIOUS: rootfs/%/bin/echo


### PR DESCRIPTION
The previous

    $(< rootfs-files)

is a Bashism that's not part of [POSIX command substitution][1].  For Bash, the `$(< …)` form is slightly faster (no need to exec `cat`), but not everyone uses Bash.

@liangchenye, I bet this is what was [happening to you][2].

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03
[2]: https://github.com/opencontainers/runtime-tools/pull/598#issuecomment-372991838