### PR TITLE
docs/command-line-interface: Require complete runtime coverage

### DIFF
--- a/docs/command-line-interface.md
+++ b/docs/command-line-interface.md
@@ -1,6 +1,6 @@
 # OCI Runtime Command Line Interface
 
-This file defines the OCI Runtime Command Line Interface version 1.0.0.
+This file defines the OCI Runtime Command Line Interface version 1.0.1.
 It is one of potentially several [runtime APIs supported by the runtime compliance test suite](runtime-compliance-testing.md#supported-apis).
 
 ## Notation
@@ -30,6 +30,9 @@ That executable MUST support commands with the following template:
 ```
 $ funC [global-options] <COMMAND> [command-specific-options] <command-specific-arguments>
 ```
+
+The runtime MUST support the entire API defined in this specification.
+Runtimes MAY also support additional options and commands as extensions to this API, but callers interested in OCI-runtime portability SHOULD NOT rely on those extensions.
 
 ## Global options
 

--- a/docs/runtime-compliance-testing.md
+++ b/docs/runtime-compliance-testing.md
@@ -4,6 +4,6 @@
 
 In order to be tested for [compliance][], runtimes MUST support at least one of the following APIs:
 
-* Version 1.0.0 of the [OCI Runtime Command Line Interface](command-line-interface.md).
+* Version 1.0.1 of the [OCI Runtime Command Line Interface](command-line-interface.md).
 
 [compliance]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc4/spec.md#notational-conventions


### PR DESCRIPTION
I didn't see wording in the previous version of this spec to require runtimes to support the full API, so I've added language for that here.  This ensures that callers who only need the specified API will be able to run with an any runtime that is compliant with this API.  You could get some way towards this requirement before by leaning on
[the spec's][1]:

> An implementation is compliant if it satisfies all the applicable MUST, REQUIRED, and SHALL requirements.

but there are a number of requirements that currently lack lower-level MUSTs.  For example, without the full-API requirement, the only [`delete`][2] requirement would be:

> The runtime MUST NOT attempt to read from its stdin.

You could have argued that a runtime which did not implement `delete` satisfied that condition, and so was “compliant” even in the absence of `delete` support.  However, such a runtime would likely break all compliant callers.  This commit ensures that such a runtime would clearly be “not compliant”.

The portability SHOULD NOT is just a hint to callers.  If you require extentions beyond this API spec, you'll want to ensure you are comfortable with the potential reduction in compatible runtimes.

I've made a patch-level version bump for this commit.  If you consider the new requirement to be an extention from the previous spec, there was no way to be a caller rely on any 1.0.0 API calls working.  I think the new explicit requirement was an implicit requirement of the 1.0.0, and that sort of typo fix deserves a patch-level bump.  For example, we've been requiring runtimes to support `create` in `validation/create.go` since those tests landed.  This commit just gives us a MUST we can cite for those (and other similar) failures.

[1]: https://github.com/opencontainers/runtime-tools/blob/v0.5.0/docs/command-line-interface.md#compliance
[2]: https://github.com/opencontainers/runtime-tools/blob/v0.5.0/docs/command-line-interface.md#delete