### PR TITLE
runtimetest: fix a validation test for unbindable mount

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -383,7 +383,7 @@ func validateRootfsPropagation(spec *rspec.Spec, t *tap.T) error {
 		}
 		return fmt.Errorf("rootfs should be %s, but not", spec.Linux.RootfsPropagation)
 	case "unbindable":
-		if err := unix.Mount("/", targetDir, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		if err := unix.Mount("/", targetDir, "", unix.MS_UNBINDABLE|unix.MS_REC, ""); err != nil {
 			if err == syscall.EINVAL {
 				return nil
 			}


### PR DESCRIPTION
`validation/linux_rootfs_propagation_unbindable.t` fails with the following message:

```
not ok 17 - rootfs propagation
  ---
  {
    "error": "rootfs expected to be unbindable, but not"
  }
```

That's because mount flag is set to `MS_BIND`. This should be actually `MS_UNBINDABLE`.

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>