### PR TITLE
validation: Complete process test

### DIFF
--- a/validation/process.go
+++ b/validation/process.go
@@ -12,6 +12,8 @@ func main() {
 	if err != nil {
 		util.Fatal(err)
 	}
+
+	g.SetProcessConsoleSize(10, 80)
 	g.SetProcessCwd("/test")
 	g.AddProcessEnv("testa", "valuea")
 	g.AddProcessEnv("testb", "123")


### PR DESCRIPTION
I try to set `terminal` to true. But it failed when testing.

```
failed to create the container
cannot allocate tty if runc will detach without setting console socket
exit status 1
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>