### PR TITLE
runtimetest: correctly check for a readable directory

### DIFF
--- a/validation/linux_masked_paths.go
+++ b/validation/linux_masked_paths.go
@@ -21,6 +21,12 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// create a temp file to make testDir non-empty
+		tmpfile, err := ioutil.TempFile(testDir, "tmp")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(tmpfile.Name())
 
 		testFile := filepath.Join(path, "masked-file")
 

--- a/validation/linux_readonly_paths.go
+++ b/validation/linux_readonly_paths.go
@@ -21,6 +21,12 @@ func main() {
 		if err != nil {
 			return err
 		}
+		// create a temp file to make testDir non-empty
+		tmpfile, err := ioutil.TempFile(testDir, "tmp")
+		if err != nil {
+			return err
+		}
+		defer os.Remove(tmpfile.Name())
 
 		testFile := filepath.Join(path, "readonly-file")
 


### PR DESCRIPTION
So far tests linux_masked_paths.t & linux_readonly_paths.t have failed with error messages like `cannot test read access for "/dirname"`. That's because `testReadAccess()` only checked if the given path is a regular file, returning an error for every other case. `testReadAccess()` should actually take care of another case of a given
path being a directory, to be able to correctly check for its readability.

Also run `testFileReadAccess()` or `testFileWriteAccess()` for all file types, not only a normal file, because the runtime spec does not mandate the type of masked files. It could be actually any file, including a character device like `/dev/null`, especially in case of runc.

Found by @alban.

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>