### PR TITLE
validation: create: don't skip errors on state

### DIFF
--- a/validation/create.go
+++ b/validation/create.go
@@ -70,14 +70,13 @@ func main() {
 
 		if err == nil {
 			state, err := r.State()
+			t.Ok(err == nil && state.ID == c.id, "'state' MUST return the state of a container")
 			if err == nil {
-				t.Ok(state.ID == c.id, "'state' MUST return the state of a container")
 				t.YAML(map[string]string{
 					"container ID": c.id,
 					"state ID":     state.ID,
 				})
 			} else {
-				t.Skip(1, "'state' MUST return the state of a container")
 				diagnostic = map[string]string{
 					"error": err.Error(),
 				}


### PR DESCRIPTION
If the runtime fails to give us the state, don't just ignore this and
skip the test but ensure we print "not ok" in the TAP output.

Signed-off-by: Alban Crequy <alban@kinvolk.io>