### PR TITLE
validation: add test for NSProcInPath

### DIFF
--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -12,6 +12,21 @@ import (
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
+func getRuntimeToolsNamespace(ns string) string {
+	// Deal with exceptional cases of "net" and "mnt", because those strings
+	// cannot be recognized by mapStrToNamespace(), which actually expects
+	// "network" and "mount" respectively.
+	switch ns {
+	case "net":
+		return "network"
+	case "mnt":
+		return "mount"
+	}
+
+	// In other cases, return just the original string
+	return ns
+}
+
 func testNamespacePath(t *tap.T, ns string, unshareOpt string) error {
 	// Calling 'unshare' (part of util-linux) is easier than doing it from
 	// Golang: mnt namespaces cannot be unshared from multithreaded

--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -107,15 +107,6 @@ func checkNamespacePath(unsharePid int, ns string) error {
 	rtns := getRuntimeToolsNamespace(ns)
 	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
 
-	// The spec is not clear about userns mappings when reusing an
-	// existing userns. Anyway in reality, we should set up uid/gid
-	// mappings, to make userns work in most runtimes.
-	// See https://github.com/opencontainers/runtime-spec/issues/961
-	//         if ns == "user" {
-	//             g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(1000))
-	//             g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(1000))
-	//         }
-
 	return util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
 		containerNsPath := fmt.Sprintf("/proc/%d/ns/%s", state.Pid, ns)
 		containerNsInode, err := os.Readlink(containerNsPath)
@@ -164,12 +155,10 @@ func main() {
 		name       string
 		unshareOpt string
 	}{
-		{"cgroup", "--cgroup"},
 		{"ipc", "--ipc"},
 		{"mnt", "--mount"},
 		{"net", "--net"},
 		{"pid", "--pid"},
-		{"user", "--user"},
 		{"uts", "--uts"},
 	}
 

--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/validation/util"
+)
+
+func testNamespacePath(t *tap.T, ns string, unshareOpt string) error {
+	// Calling 'unshare' (part of util-linux) is easier than doing it from
+	// Golang: mnt namespaces cannot be unshared from multithreaded
+	// programs.
+	cmd := exec.Command("unshare", unshareOpt, "--fork", "sleep", "10000")
+	err := cmd.Start()
+	if err != nil {
+		return fmt.Errorf("cannot run unshare: %s", err)
+	}
+	defer func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+		cmd.Wait()
+	}()
+	if cmd.Process == nil {
+		return fmt.Errorf("process failed to start")
+	}
+	unsharePid := cmd.Process.Pid
+
+	// Wait until 'unshare' switched its namespace
+	// TODO: avoid synchronisation with sleeps.
+	time.Sleep(time.Second)
+
+	specialChildren := ""
+	if ns == "pid" {
+		// Unsharing pidns does not move the process into the new
+		// pidns but the next forked process. 'unshare' is called with
+		// '--fork' so the pidns will be fully created and populated
+		// with a pid 1.
+		//
+		// However, finding out the pid of the child process is not
+		// trivial: it would require to parse
+		// /proc/$pid/task/$tid/children but that only works on kernels
+		// with CONFIG_PROC_CHILDREN (not all distros have that).
+		//
+		// It is easier to look at /proc/$pid/ns/pid_for_children on
+		// the parent process. Available since Linux 4.12.
+		specialChildren = "_for_children"
+	}
+	unshareNsPath := fmt.Sprintf("/proc/%d/ns/%s", unsharePid, ns+specialChildren)
+	unshareNsInode, err := os.Readlink(unshareNsPath)
+	if err != nil {
+		return fmt.Errorf("cannot read namespace link for the unshare process: %s", err)
+	}
+
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		return fmt.Errorf("cannot get the default generator: %v", err)
+	}
+
+	rtns := getRuntimeToolsNamespace(ns)
+	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
+
+	// The spec is not clear about userns mappings when reusing an
+	// existing userns.
+	// See https://github.com/opencontainers/runtime-spec/issues/961
+	//if ns == "user" {
+	//	g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(1000))
+	//	g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(1000))
+	//}
+
+	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+		containerNsPath := fmt.Sprintf("/proc/%d/ns/%s", state.Pid, ns)
+		containerNsInode, err := os.Readlink(containerNsPath)
+		if err != nil {
+			out, err2 := exec.Command("sh", "-c", fmt.Sprintf("ls -la /proc/%d/ns/", state.Pid)).CombinedOutput()
+			return fmt.Errorf("cannot read namespace link for the container process: %s\n%v\n%v", err, err2, out)
+		}
+		if containerNsInode != unshareNsInode {
+			return fmt.Errorf("expected: %q, found: %q", unshareNsInode, containerNsInode)
+		}
+		return nil
+	})
+
+	return err
+}
+
+func main() {
+	t := tap.New()
+	t.Header(0)
+
+	cases := []struct {
+		name       string
+		unshareOpt string
+	}{
+		{"cgroup", "--cgroup"},
+		{"ipc", "--ipc"},
+		{"mnt", "--mount"},
+		{"net", "--net"},
+		{"pid", "--pid"},
+		{"user", "--user"},
+		{"uts", "--uts"},
+	}
+
+	for _, c := range cases {
+		if "linux" != runtime.GOOS {
+			t.Skip(1, fmt.Sprintf("linux-specific namespace test: %s", c))
+		}
+
+		err := testNamespacePath(t, c.name, c.unshareOpt)
+		t.Ok(err == nil, fmt.Sprintf("set %s namespace by path", c.name))
+		if err != nil {
+			diagnostic := map[string]string{
+				"error": err.Error(),
+			}
+			t.YAML(diagnostic)
+		}
+	}
+
+	t.AutoPlan()
+}

--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -181,13 +181,16 @@ func main() {
 		err := testNamespacePath(t, c.name, c.unshareOpt)
 		t.Ok(err == nil, fmt.Sprintf("set %s namespace by path", c.name))
 		if err != nil {
-			specErr := specerror.NewError(specerror.NSProcInPath, err, rspec.Version)
+			rfcError, errRfc := specerror.NewRFCError(specerror.NSProcInPath, err, rspec.Version)
+			if errRfc != nil {
+				continue
+			}
 			diagnostic := map[string]string{
 				"actual":         fmt.Sprintf("err == %v", err),
 				"expected":       "err == nil",
 				"namespace type": c.name,
-				"level":          specErr.(*specerror.Error).Err.Level.String(),
-				"reference":      specErr.(*specerror.Error).Err.Reference,
+				"level":          rfcError.Level.String(),
+				"reference":      rfcError.Reference,
 			}
 			t.YAML(diagnostic)
 		}

--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -28,6 +28,100 @@ func getRuntimeToolsNamespace(ns string) string {
 	return ns
 }
 
+func waitForState(stateCheckFunc func() error) error {
+	timeout := 3 * time.Second
+	alarm := time.After(timeout)
+	ticker := time.Tick(200 * time.Millisecond)
+	for {
+		select {
+		case <-alarm:
+			return fmt.Errorf("failed to reach expected state within %v", timeout)
+		case <-ticker:
+			if err := stateCheckFunc(); err == nil {
+				return nil
+			}
+		}
+	}
+}
+
+func checkNamespacePath(unsharePid int, ns string) error {
+	testNsPath := fmt.Sprintf("/proc/%d/ns/%s", os.Getpid(), ns)
+	testNsInode, err := os.Readlink(testNsPath)
+	if err != nil {
+		out, err2 := exec.Command("sh", "-c", fmt.Sprintf("ls -la /proc/%d/ns/", os.Getpid())).CombinedOutput()
+		return fmt.Errorf("cannot read namespace link for the test process: %s\n%v\n%v", err, err2, string(out))
+	}
+
+	unshareNsPath := ""
+	unshareNsInode := ""
+
+	doCheckNamespacePath := func() error {
+		specialChildren := ""
+		if ns == "pid" {
+			// Unsharing pidns does not move the process into the new
+			// pidns but the next forked process. 'unshare' is called with
+			// '--fork' so the pidns will be fully created and populated
+			// with a pid 1.
+			//
+			// However, finding out the pid of the child process is not
+			// trivial: it would require to parse
+			// /proc/$pid/task/$tid/children but that only works on kernels
+			// with CONFIG_PROC_CHILDREN (not all distros have that).
+			//
+			// It is easier to look at /proc/$pid/ns/pid_for_children on
+			// the parent process. Available since Linux 4.12.
+			specialChildren = "_for_children"
+		}
+		unshareNsPath = fmt.Sprintf("/proc/%d/ns/%s", unsharePid, ns+specialChildren)
+		unshareNsInode, err = os.Readlink(unshareNsPath)
+		if err != nil {
+			return fmt.Errorf("cannot read namespace link for the unshare process: %s", err)
+		}
+
+		if testNsInode == unshareNsInode {
+			return fmt.Errorf("expected: %q, found: %q", testNsInode, unshareNsInode)
+		}
+
+		return nil
+	}
+
+	// Since it takes some time until unshare switched to the new namespace,
+	// we should make a loop to check for the result up to 3 seconds.
+	if err := waitForState(doCheckNamespacePath); err != nil {
+		return err
+	}
+
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		return fmt.Errorf("cannot get the default generator: %v", err)
+	}
+
+	rtns := getRuntimeToolsNamespace(ns)
+	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
+
+	// The spec is not clear about userns mappings when reusing an
+	// existing userns. Anyway in reality, we should set up uid/gid
+	// mappings, to make userns work in most runtimes.
+	// See https://github.com/opencontainers/runtime-spec/issues/961
+	//         if ns == "user" {
+	//             g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(1000))
+	//             g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(1000))
+	//         }
+
+	return util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+		containerNsPath := fmt.Sprintf("/proc/%d/ns/%s", state.Pid, ns)
+		containerNsInode, err := os.Readlink(containerNsPath)
+		if err != nil {
+			out, err2 := exec.Command("sh", "-c", fmt.Sprintf("ls -la /proc/%d/ns/", state.Pid)).CombinedOutput()
+			return fmt.Errorf("cannot read namespace link for the container process: %s\n%v\n%v", err, err2, out)
+		}
+		if containerNsInode != unshareNsInode {
+			return fmt.Errorf("expected: %q, found: %q", unshareNsInode, containerNsInode)
+		}
+		return nil
+	})
+}
+
 func testNamespacePath(t *tap.T, ns string, unshareOpt string) error {
 	// Calling 'unshare' (part of util-linux) is easier than doing it from
 	// Golang: mnt namespaces cannot be unshared from multithreaded
@@ -50,64 +144,8 @@ func testNamespacePath(t *tap.T, ns string, unshareOpt string) error {
 	if cmd.Process == nil {
 		return fmt.Errorf("process failed to start")
 	}
-	unsharePid := cmd.Process.Pid
 
-	// Wait until 'unshare' switched its namespace
-	// TODO: avoid synchronisation with sleeps.
-	time.Sleep(time.Second)
-
-	specialChildren := ""
-	if ns == "pid" {
-		// Unsharing pidns does not move the process into the new
-		// pidns but the next forked process. 'unshare' is called with
-		// '--fork' so the pidns will be fully created and populated
-		// with a pid 1.
-		//
-		// However, finding out the pid of the child process is not
-		// trivial: it would require to parse
-		// /proc/$pid/task/$tid/children but that only works on kernels
-		// with CONFIG_PROC_CHILDREN (not all distros have that).
-		//
-		// It is easier to look at /proc/$pid/ns/pid_for_children on
-		// the parent process. Available since Linux 4.12.
-		specialChildren = "_for_children"
-	}
-	unshareNsPath := fmt.Sprintf("/proc/%d/ns/%s", unsharePid, ns+specialChildren)
-	unshareNsInode, err := os.Readlink(unshareNsPath)
-	if err != nil {
-		return fmt.Errorf("cannot read namespace link for the unshare process: %s", err)
-	}
-
-	g, err := util.GetDefaultGenerator()
-	if err != nil {
-		return fmt.Errorf("cannot get the default generator: %v", err)
-	}
-
-	rtns := getRuntimeToolsNamespace(ns)
-	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
-
-	// The spec is not clear about userns mappings when reusing an
-	// existing userns.
-	// See https://github.com/opencontainers/runtime-spec/issues/961
-	//if ns == "user" {
-	//	g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(1000))
-	//	g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(1000))
-	//}
-
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		containerNsPath := fmt.Sprintf("/proc/%d/ns/%s", state.Pid, ns)
-		containerNsInode, err := os.Readlink(containerNsPath)
-		if err != nil {
-			out, err2 := exec.Command("sh", "-c", fmt.Sprintf("ls -la /proc/%d/ns/", state.Pid)).CombinedOutput()
-			return fmt.Errorf("cannot read namespace link for the container process: %s\n%v\n%v", err, err2, out)
-		}
-		if containerNsInode != unshareNsInode {
-			return fmt.Errorf("expected: %q, found: %q", unshareNsInode, containerNsInode)
-		}
-		return nil
-	})
-
-	return err
+	return checkNamespacePath(cmd.Process.Pid, ns)
 }
 
 func main() {


### PR DESCRIPTION
This PR validates `NSProcInPath`, i.e. `The runtime MUST place the container process in the namespace associated with that path`. It checks that Linux namespaces are created with a given path by making use of `util.RuntimeOutsideValidate()`. 

Since the [previous version of PR](https://github.com/opencontainers/runtime-tools/pull/613), we had to fix the following things:

* Fix a bug caused by namespace string mismatches, found by @alban.
* Kill the unshare process as well as child processes at once, making use of `setpgid()`.
* Use a ticker loop instead of a pure sleep call for general sync mechanism.
* Print out correct diagnostics based on specError.

This PR replaces https://github.com/opencontainers/runtime-tools/pull/613.
See also https://github.com/opencontainers/runtime-tools/issues/572.
