### PR TITLE
travis: fix fetch issue of golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ go:
 sudo: false
 
 before_install:
-  - go get github.com/golang/lint/golint
+  - mkdir --parents $GOPATH/src/golang.org/x
+    && git clone --depth=1 https://go.googlesource.com/lint $GOPATH/src/golang.org/x/lint
+    && go get golang.org/x/lint/golint
   - go get github.com/vbatts/git-validation
 
 install: true


### PR DESCRIPTION
As golint repo does not return metadata for `go get` to work correctly, every travis build fails. Let's install golint without using go get until it's fixed.

See also https://github.com/golang/lint/issues/397

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>