### PR TITLE
validation: add cgroup devices validation

### DIFF
--- a/validation/linux_cgroups_devices.go
+++ b/validation/linux_cgroups_devices.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/opencontainers/runtime-tools/cgroups"
+	"github.com/opencontainers/runtime-tools/validation/util"
+)
+
+func main() {
+	var major1, minor1, major2, minor2, major3, minor3 int64 = 10, 229, 8, 20, 10, 200
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
+	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+	g.AddLinuxResourcesDevice(true, "c", &major1, &minor1, "rwm")
+	g.AddLinuxResourcesDevice(true, "b", &major2, &minor2, "rw")
+	g.AddLinuxResourcesDevice(true, "b", &major3, &minor3, "r")
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesDevices)
+	if err != nil {
+		util.Fatal(err)
+	}
+}

--- a/validation/linux_cgroups_relative_devices.go
+++ b/validation/linux_cgroups_relative_devices.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/opencontainers/runtime-tools/cgroups"
+	"github.com/opencontainers/runtime-tools/validation/util"
+)
+
+func main() {
+	var major1, minor1, major2, minor2, major3, minor3 int64 = 10, 229, 8, 20, 10, 200
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
+	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
+	g.AddLinuxResourcesDevice(true, "c", &major1, &minor1, "rwm")
+	g.AddLinuxResourcesDevice(true, "b", &major2, &minor2, "rw")
+	g.AddLinuxResourcesDevice(true, "b", &major3, &minor3, "r")
+	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesDevices)
+	if err != nil {
+		util.Fatal(err)
+	}
+}

--- a/validation/util/linux_resources_devices.go
+++ b/validation/util/linux_resources_devices.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+	"github.com/opencontainers/runtime-tools/specerror"
+)
+
+// ValidateLinuxResourcesDevices validates linux.resources.devices.
+func ValidateLinuxResourcesDevices(config *rspec.Spec, state *rspec.State) error {
+	t := tap.New()
+	t.Header(0)
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find devices")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	lnd, err := cg.GetDevicesData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get devices data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		t.AutoPlan()
+		return nil
+	}
+
+	for i, device := range config.Linux.Resources.Devices {
+		if device.Allow == true {
+			found := false
+			if lnd[i-1].Type == device.Type && *lnd[i-1].Major == *device.Major && *lnd[i-1].Minor == *device.Minor && lnd[i-1].Access == device.Access {
+				found = true
+			}
+			t.Ok(found, fmt.Sprintf("devices %s %d:%d %s is set correctly", device.Type, *device.Major, *device.Minor, device.Access))
+			t.Diagnosticf("expect: %s %d:%d %s, actual: %s %d:%d %s",
+				device.Type, *device.Major, *device.Minor, device.Access, lnd[i-1].Type, *lnd[i-1].Major, *lnd[i-1].Minor, lnd[i-1].Access)
+			if !found {
+				err := specerror.NewError(specerror.DevicesApplyInOrder, fmt.Errorf("The runtime MUST apply entries in the listed order"), rspec.Version)
+				t.Diagnostic(err.Error())
+				t.AutoPlan()
+				return nil
+			}
+		}
+	}
+
+	t.AutoPlan()
+	return nil
+}


### PR DESCRIPTION
On the one hand in order to achieve devices validation, on the other hand in order to achieve the following `specerror`：


`DevicesApplyInOrder`: The runtime MUST apply entries in the listed order.


But the test results are not the same as I expected, so I want to see what do you think.
```
➜  runtime-tools git:(devices-validation) ✗ sudo ./validation/linux_cgroups_devices.t
TAP version 13
ok 1 - find devices
ok 2 - get devices data
not ok 3 - devices c 10:229 rwm is set correctly
# expect: c 10:229 rwm, actual: a 0:0 rwm
not ok 4 - devices a 10:200 r is set correctly
# expect: a 10:200 r, actual: a 0:0 rwm
1..4
```
@wking @liangchenye @alban @dongsupark PTAL

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>