### PR TITLE
validation: test cgroups with different input values

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -94,7 +94,8 @@ func (g *Generator) initConfigLinuxResourcesBlockIO() {
 	}
 }
 
-func (g *Generator) initConfigLinuxResourcesCPU() {
+// InitConfigLinuxResourcesCPU initializes CPU of Linux resources
+func (g *Generator) InitConfigLinuxResourcesCPU() {
 	g.initConfigLinuxResources()
 	if g.Config.Linux.Resources.CPU == nil {
 		g.Config.Linux.Resources.CPU = &rspec.LinuxCPU{}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -703,43 +703,43 @@ func (g *Generator) DropLinuxResourcesBlockIOThrottleWriteIOPSDevice(major int64
 
 // SetLinuxResourcesCPUShares sets g.Config.Linux.Resources.CPU.Shares.
 func (g *Generator) SetLinuxResourcesCPUShares(shares uint64) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.Shares = &shares
 }
 
 // SetLinuxResourcesCPUQuota sets g.Config.Linux.Resources.CPU.Quota.
 func (g *Generator) SetLinuxResourcesCPUQuota(quota int64) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.Quota = &quota
 }
 
 // SetLinuxResourcesCPUPeriod sets g.Config.Linux.Resources.CPU.Period.
 func (g *Generator) SetLinuxResourcesCPUPeriod(period uint64) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.Period = &period
 }
 
 // SetLinuxResourcesCPURealtimeRuntime sets g.Config.Linux.Resources.CPU.RealtimeRuntime.
 func (g *Generator) SetLinuxResourcesCPURealtimeRuntime(time int64) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.RealtimeRuntime = &time
 }
 
 // SetLinuxResourcesCPURealtimePeriod sets g.Config.Linux.Resources.CPU.RealtimePeriod.
 func (g *Generator) SetLinuxResourcesCPURealtimePeriod(period uint64) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.RealtimePeriod = &period
 }
 
 // SetLinuxResourcesCPUCpus sets g.Config.Linux.Resources.CPU.Cpus.
 func (g *Generator) SetLinuxResourcesCPUCpus(cpus string) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.Cpus = cpus
 }
 
 // SetLinuxResourcesCPUMems sets g.Config.Linux.Resources.CPU.Mems.
 func (g *Generator) SetLinuxResourcesCPUMems(mems string) {
-	g.initConfigLinuxResourcesCPU()
+	g.InitConfigLinuxResourcesCPU()
 	g.Config.Linux.Resources.CPU.Mems = mems
 }
 

--- a/validation/linux_cgroups_blkio.go
+++ b/validation/linux_cgroups_blkio.go
@@ -1,16 +1,23 @@
 package main
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
-func main() {
+func testBlkioCgroups(rate uint64, isEmpty bool) error {
 	var weight uint16 = 500
 	var leafWeight uint16 = 300
-	var major, minor int64 = 8, 0
-	var rate uint64 = 102400
+
+	// It's assumed that a device /dev/sda (8:0) exists on the test system.
+	// The minor number must be always 0, as it's only allowed to set blkio
+	// weights to a whole block device /dev/sda, not to partitions like sda1.
+	var major int64 = 8
+	var minor int64
 
 	t := tap.New()
 	t.Header(0)
@@ -18,19 +25,48 @@ func main() {
 
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
-		util.Fatal(err)
+		return err
 	}
+
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
-	g.SetLinuxResourcesBlockIOWeight(weight)
-	g.SetLinuxResourcesBlockIOLeafWeight(leafWeight)
+
+	if !isEmpty {
+		g.SetLinuxResourcesBlockIOWeight(weight)
+		g.SetLinuxResourcesBlockIOLeafWeight(leafWeight)
+	}
+
 	g.AddLinuxResourcesBlockIOWeightDevice(major, minor, weight)
 	g.AddLinuxResourcesBlockIOLeafWeightDevice(major, minor, leafWeight)
 	g.AddLinuxResourcesBlockIOThrottleReadBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
+
 	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
-		util.Fatal(err)
+		return err
+	}
+	return nil
+}
+
+func main() {
+	if "linux" != runtime.GOOS {
+		util.Fatal(fmt.Errorf("linux-specific cgroup test"))
+	}
+
+	cases := []struct {
+		rate    uint64
+		isEmpty bool
+	}{
+		{102400, false},
+		{204800, false},
+		{102400, true},
+		{204800, true},
+	}
+
+	for _, c := range cases {
+		if err := testBlkioCgroups(c.rate, c.isEmpty); err != nil {
+			util.Fatal(err)
+		}
 	}
 }

--- a/validation/linux_cgroups_blkio.go
+++ b/validation/linux_cgroups_blkio.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -10,6 +11,11 @@ func main() {
 	var leafWeight uint16 = 300
 	var major, minor int64 = 8, 0
 	var rate uint64 = 102400
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -23,7 +29,7 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -2,68 +2,132 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/mndrix/tap-go"
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
-func main() {
-	var shares uint64 = 1024
-	var period uint64 = 100000
-	var quota int64 = 50000
-	var cpus, mems string = "0-1", "0"
+const (
+	defaultRealtimePeriod  uint64 = 1000000
+	defaultRealtimeRuntime int64  = 950000
+)
+
+func testCPUCgroups() error {
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
+	CPUrange := fmt.Sprintf("0-%d", runtime.NumCPU()-1)
+
+	// Test with different combinations of values.
+	// NOTE: most systems have only one memory node (mems=="0"), so we cannot
+	// simply test with multiple values of mems.
+	cases := []struct {
+		shares uint64
+		period uint64
+		quota  int64
+		cpus   string
+		mems   string
+	}{
+		{1024, 100000, 50000, "0", "0"},
+		{1024, 100000, 50000, CPUrange, "0"},
+		{1024, 100000, 200000, "0", "0"},
+		{1024, 100000, 200000, CPUrange, "0"},
+		{1024, 500000, 50000, "0", "0"},
+		{1024, 500000, 50000, CPUrange, "0"},
+		{1024, 500000, 200000, "0", "0"},
+		{1024, 500000, 200000, CPUrange, "0"},
+		{2048, 100000, 50000, "0", "0"},
+		{2048, 100000, 50000, CPUrange, "0"},
+		{2048, 100000, 200000, "0", "0"},
+		{2048, 100000, 200000, CPUrange, "0"},
+		{2048, 500000, 50000, "0", "0"},
+		{2048, 500000, 50000, CPUrange, "0"},
+		{2048, 500000, 200000, "0", "0"},
+		{2048, 500000, 200000, CPUrange, "0"},
+	}
+
+	for _, c := range cases {
+		g, err := util.GetDefaultGenerator()
+		if err != nil {
+			return fmt.Errorf("cannot get default config from generator: %v", err)
+		}
+
+		g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+
+		if c.shares > 0 {
+			g.SetLinuxResourcesCPUShares(c.shares)
+		}
+
+		if c.period > 0 {
+			g.SetLinuxResourcesCPUPeriod(c.period)
+		}
+
+		if c.quota > 0 {
+			g.SetLinuxResourcesCPUQuota(c.quota)
+		}
+
+		if c.cpus != "" {
+			g.SetLinuxResourcesCPUCpus(c.cpus)
+		}
+
+		if c.mems != "" {
+			g.SetLinuxResourcesCPUMems(c.mems)
+		}
+
+		// NOTE: On most systems where CONFIG_RT_GROUP & CONFIG_RT_GROUP_SCHED are not enabled,
+		// the following tests will fail, because sysfs knobs like
+		// /sys/fs/cgroup/cpu,cpuacct/cpu.rt_{period,runtime}_us do not exist.
+		// So we need to check if the sysfs knobs exist before setting the variables.
+		if _, err := os.Stat(filepath.Join(util.CPUCgroupPrefix, "cpu.rt_period_us")); !os.IsNotExist(err) {
+			g.SetLinuxResourcesCPURealtimePeriod(defaultRealtimePeriod)
+		}
+
+		if _, err := os.Stat(filepath.Join(util.CPUCgroupPrefix, "cpu.rt_runtime_us")); !os.IsNotExist(err) {
+			g.SetLinuxResourcesCPURealtimeRuntime(defaultRealtimeRuntime)
+		}
+
+		if err := util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesCPU); err != nil {
+			return fmt.Errorf("cannot validate CPU cgroups: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func testEmptyCPU() error {
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
+		return fmt.Errorf("cannot get default config from generator: %v", err)
+	}
+	g.InitConfigLinuxResourcesCPU()
+	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+
+	if err := util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesCPUEmpty); err != nil {
+		return fmt.Errorf("cannot validate empty CPU cgroups: %v", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if "linux" != runtime.GOOS {
+		util.Fatal(fmt.Errorf("linux-specific cgroup test"))
+	}
+
+	if err := testCPUCgroups(); err != nil {
 		util.Fatal(err)
 	}
-	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
-	g.SetLinuxResourcesCPUShares(shares)
-	g.SetLinuxResourcesCPUQuota(quota)
-	g.SetLinuxResourcesCPUPeriod(period)
-	g.SetLinuxResourcesCPUCpus(cpus)
-	g.SetLinuxResourcesCPUMems(mems)
-	err = util.RuntimeOutsideValidate(g, nil, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
 
-		if lcd.Shares == nil {
-			return fmt.Errorf("unable to get cpu shares, lcd.Shares == %v", lcd.Shares)
-		}
-		if *lcd.Shares != shares {
-			return fmt.Errorf("cpus shares limit is not set correctly, expect: %d, actual: %d", shares, *lcd.Shares)
-		}
-
-		if lcd.Quota == nil {
-			return fmt.Errorf("unable to get cpu quota, lcd.Quota == %v", lcd.Quota)
-		}
-		if *lcd.Quota != quota {
-			return fmt.Errorf("cpus quota is not set correctly, expect: %d, actual: %d", quota, *lcd.Quota)
-		}
-
-		if lcd.Period == nil {
-			return fmt.Errorf("unable to get cpu period, lcd.Period == %v", lcd.Period)
-		}
-		if *lcd.Period != period {
-			return fmt.Errorf("cpus period is not set correctly, expect: %d, actual: %d", period, *lcd.Period)
-		}
-		if lcd.Cpus != cpus {
-			return fmt.Errorf("cpus cpus is not set correctly, expect: %s, actual: %s", cpus, lcd.Cpus)
-		}
-		if lcd.Mems != mems {
-			return fmt.Errorf("cpus mems is not set correctly, expect: %s, actual: %s", mems, lcd.Mems)
-		}
-		return nil
-	})
-
-	if err != nil {
+	if err := testEmptyCPU(); err != nil {
 		util.Fatal(err)
 	}
 }

--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
@@ -23,7 +24,7 @@ func main() {
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, nil, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err

--- a/validation/linux_cgroups_devices.go
+++ b/validation/linux_cgroups_devices.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
 	var major1, minor1, major2, minor2, major3, minor3 int64 = 10, 229, 8, 20, 10, 200
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -15,8 +21,8 @@ func main() {
 	g.AddLinuxResourcesDevice(true, "c", &major1, &minor1, "rwm")
 	g.AddLinuxResourcesDevice(true, "b", &major2, &minor2, "rw")
 	g.AddLinuxResourcesDevice(true, "b", &major3, &minor3, "r")
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesDevices)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesDevices)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
@@ -17,7 +18,7 @@ func main() {
 	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, nil, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		if err != nil {
 			return err

--- a/validation/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -9,32 +10,95 @@ import (
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
-func main() {
-	page := "1GB"
-	var limit uint64 = 52985 * 1024 * 1024 * 1024 // multiple of hugepage size
+func testHugetlbCgroups() error {
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
+	// limit =~ 100 * page size
+	// NOTE: on some systems, pagesize "1GB" doesn't seem to work.
+	// Ideally we should auto-detect the value.
+	cases := []struct {
+		page  string
+		limit uint64
+	}{
+		{"2MB", 100 * 2 * 1024 * 1024},
+		{"1GB", 100 * 1024 * 1024 * 1024},
+		{"2MB", 100 * 2 * 1024 * 1024},
+		{"1GB", 100 * 1024 * 1024 * 1024},
+	}
+
+	for _, c := range cases {
+		g, err := util.GetDefaultGenerator()
+		if err != nil {
+			return err
+		}
+		g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+		g.AddLinuxResourcesHugepageLimit(c.page, c.limit)
+		err = util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
+			cg, err := cgroups.FindCgroup()
+			if err != nil {
+				return err
+			}
+			lhd, err := cg.GetHugepageLimitData(state.Pid, config.Linux.CgroupsPath)
+			if err != nil {
+				return err
+			}
+			for _, lhl := range lhd {
+				if lhl.Pagesize != c.page {
+					continue
+				}
+				t.Ok(lhl.Limit == c.limit, "hugepage limit is set correctly")
+				t.Diagnosticf("expect: %d, actual: %d", c.limit, lhl.Limit)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testWrongHugetlb() error {
+	// We deliberately set the page size to a wrong value, "3MB", to see
+	// if the container really returns an error.
+	page := "3MB"
+	var limit uint64 = 100 * 3 * 1024 * 1024
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
-		util.Fatal(err)
+		return err
 	}
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.AddLinuxResourcesHugepageLimit(page, limit)
-	err = util.RuntimeOutsideValidate(g, nil, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
-		cg, err := cgroups.FindCgroup()
-		if err != nil {
-			return err
-		}
-		lhd, err := cg.GetHugepageLimitData(state.Pid, config.Linux.CgroupsPath)
-		if err != nil {
-			return err
-		}
-		for _, lhl := range lhd {
-			if lhl.Pagesize == page && lhl.Limit != limit {
-				return fmt.Errorf("hugepage %s limit is not set correctly, expect: %d, actual: %d", page, limit, lhl.Limit)
-			}
-		}
+
+	err = util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		return nil
 	})
-	if err != nil {
+	t.Ok(err != nil, "hugepage invalid pagesize results in an errror")
+	if err == nil {
+		t.Diagnosticf("expect: err != nil, actual: err == nil")
+	}
+	return err
+}
+
+func main() {
+	if "linux" != runtime.GOOS {
+		util.Fatal(fmt.Errorf("linux-specific cgroup test"))
+	}
+
+	if err := testHugetlbCgroups(); err != nil {
+		util.Fatal(err)
+	}
+
+	if err := testWrongHugetlb(); err == nil {
 		util.Fatal(err)
 	}
 }

--- a/validation/linux_cgroups_memory.go
+++ b/validation/linux_cgroups_memory.go
@@ -1,33 +1,52 @@
 package main
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
-	var limit int64 = 50593792
-	var swappiness uint64 = 50
+	if "linux" != runtime.GOOS {
+		util.Fatal(fmt.Errorf("linux-specific cgroup test"))
+	}
 
 	t := tap.New()
 	t.Header(0)
-	defer t.AutoPlan()
 
-	g, err := util.GetDefaultGenerator()
-	if err != nil {
-		util.Fatal(err)
+	cases := []struct {
+		limit      int64
+		swappiness uint64
+	}{
+		{50593792, 10},
+		{50593792, 50},
+		{50593792, 100},
+		{151781376, 10},
+		{151781376, 50},
+		{151781376, 100},
 	}
-	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
-	g.SetLinuxResourcesMemoryLimit(limit)
-	g.SetLinuxResourcesMemoryReservation(limit)
-	g.SetLinuxResourcesMemorySwap(limit)
-	g.SetLinuxResourcesMemoryKernel(limit)
-	g.SetLinuxResourcesMemoryKernelTCP(limit)
-	g.SetLinuxResourcesMemorySwappiness(swappiness)
-	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesMemory)
-	if err != nil {
-		util.Fatal(err)
+
+	for _, c := range cases {
+		g, err := util.GetDefaultGenerator()
+		if err != nil {
+			util.Fatal(err)
+		}
+		g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+		g.SetLinuxResourcesMemoryLimit(c.limit)
+		g.SetLinuxResourcesMemoryReservation(c.limit)
+		g.SetLinuxResourcesMemorySwap(c.limit)
+		g.SetLinuxResourcesMemoryKernel(c.limit)
+		g.SetLinuxResourcesMemoryKernelTCP(c.limit)
+		g.SetLinuxResourcesMemorySwappiness(c.swappiness)
+		g.SetLinuxResourcesMemoryDisableOOMKiller(true)
+		err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesMemory)
+		if err != nil {
+			t.Fail(err.Error())
+		}
 	}
+
+	t.AutoPlan()
 }

--- a/validation/linux_cgroups_memory.go
+++ b/validation/linux_cgroups_memory.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -8,6 +9,11 @@ import (
 func main() {
 	var limit int64 = 50593792
 	var swappiness uint64 = 50
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -20,7 +26,7 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesMemory)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_network.go
+++ b/validation/linux_cgroups_network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -8,6 +9,11 @@ import (
 func main() {
 	var id, prio uint32 = 255, 10
 	ifName := "lo"
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -15,7 +21,7 @@ func main() {
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
 	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/linux_cgroups_network.go
+++ b/validation/linux_cgroups_network.go
@@ -1,28 +1,108 @@
 package main
 
 import (
+	"fmt"
+	"net"
+	"runtime"
+
 	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
-func main() {
-	var id, prio uint32 = 255, 10
-	ifName := "lo"
-
+func testNetworkCgroups() error {
 	t := tap.New()
 	t.Header(0)
 	defer t.AutoPlan()
 
-	g, err := util.GetDefaultGenerator()
+	loIfName := ""
+	ethIfName := ""
+
+	// we try to get the first 2 interfaces on the system, to assign
+	// the first one to loIfName, the second to ethIfName.
+	l, err := net.Interfaces()
 	if err != nil {
-		util.Fatal(err)
+		// fall back to the default list only with lo
+		loIfName = "lo"
+		ethIfName = "eth0"
+	} else {
+		loIfName = l[0].Name
+		ethIfName = l[1].Name
 	}
-	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
-	g.SetLinuxResourcesNetworkClassID(id)
-	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
-	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesNetwork)
-	if err != nil {
+
+	cases := []struct {
+		classid    uint32
+		prio       uint32
+		ifName     string
+		withNetNs  bool
+		withUserNs bool
+	}{
+		{255, 10, loIfName, true, true},
+		{255, 10, loIfName, true, false},
+		{255, 10, loIfName, false, true},
+		{255, 10, loIfName, false, false},
+		{255, 10, ethIfName, true, true},
+		{255, 10, ethIfName, true, false},
+		{255, 10, ethIfName, false, true},
+		{255, 10, ethIfName, false, false},
+		{255, 30, loIfName, true, true},
+		{255, 30, loIfName, true, false},
+		{255, 30, loIfName, false, true},
+		{255, 30, loIfName, false, false},
+		{255, 30, ethIfName, true, true},
+		{255, 30, ethIfName, true, false},
+		{255, 30, ethIfName, false, true},
+		{255, 30, ethIfName, false, false},
+		{550, 10, loIfName, true, true},
+		{550, 10, loIfName, true, false},
+		{550, 10, loIfName, false, true},
+		{550, 10, loIfName, false, false},
+		{550, 10, ethIfName, true, true},
+		{550, 10, ethIfName, true, false},
+		{550, 10, ethIfName, false, true},
+		{550, 10, ethIfName, false, false},
+		{550, 30, loIfName, true, true},
+		{550, 30, loIfName, true, false},
+		{550, 30, loIfName, false, true},
+		{550, 30, loIfName, false, false},
+		{550, 30, ethIfName, true, true},
+		{550, 30, ethIfName, true, false},
+		{550, 30, ethIfName, false, true},
+		{550, 30, ethIfName, false, false},
+	}
+
+	for _, c := range cases {
+		g, err := util.GetDefaultGenerator()
+		if err != nil {
+			return err
+		}
+
+		g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+		g.SetLinuxResourcesNetworkClassID(c.classid)
+		g.AddLinuxResourcesNetworkPriorities(c.ifName, c.prio)
+
+		if !c.withNetNs {
+			g.RemoveLinuxNamespace("network")
+		}
+		if !c.withUserNs {
+			g.RemoveLinuxNamespace("user")
+		}
+
+		err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesNetwork)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if "linux" != runtime.GOOS {
+		util.Fatal(fmt.Errorf("linux-specific cgroup test"))
+	}
+
+	if err := testNetworkCgroups(); err != nil {
 		util.Fatal(err)
 	}
 }

--- a/validation/linux_cgroups_pids.go
+++ b/validation/linux_cgroups_pids.go
@@ -1,20 +1,26 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
 	var limit int64 = 1000
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
 	}
 	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesPids)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_blkio.go
+++ b/validation/linux_cgroups_relative_blkio.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -10,6 +11,11 @@ func main() {
 	var leafWeight uint16 = 300
 	var major, minor int64 = 8, 0
 	var rate uint64 = 102400
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -23,8 +29,8 @@ func main() {
 	g.AddLinuxResourcesBlockIOThrottleWriteBpsDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleReadIOPSDevice(major, minor, rate)
 	g.AddLinuxResourcesBlockIOThrottleWriteIOPSDevice(major, minor, rate)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesBlockIO)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesBlockIO)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_cpus.go
+++ b/validation/linux_cgroups_relative_cpus.go
@@ -12,6 +12,11 @@ func main() {
 	var period uint64 = 100000
 	var quota int64 = 50000
 	var cpus, mems string = "0-1", "0"
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -22,15 +27,11 @@ func main() {
 	g.SetLinuxResourcesCPUPeriod(period)
 	g.SetLinuxResourcesCPUCpus(cpus)
 	g.SetLinuxResourcesCPUMems(mems)
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
-		t := tap.New()
-		t.Header(0)
-
+	err = util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		cg, err := cgroups.FindCgroup()
 		t.Ok((err == nil), "find cpus cgroup")
 		if err != nil {
 			t.Diagnostic(err.Error())
-			t.AutoPlan()
 			return nil
 		}
 
@@ -38,7 +39,6 @@ func main() {
 		t.Ok((err == nil), "get cpus cgroup data")
 		if err != nil {
 			t.Diagnostic(err.Error())
-			t.AutoPlan()
 			return nil
 		}
 
@@ -57,11 +57,10 @@ func main() {
 		t.Ok(lcd.Mems == mems, "cpus mems is set correctly")
 		t.Diagnosticf("expect: %s, actual: %s", mems, lcd.Mems)
 
-		t.AutoPlan()
 		return nil
 	})
 
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_devices.go
+++ b/validation/linux_cgroups_relative_devices.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
 	var major1, minor1, major2, minor2, major3, minor3 int64 = 10, 229, 8, 20, 10, 200
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -15,8 +21,8 @@ func main() {
 	g.AddLinuxResourcesDevice(true, "c", &major1, &minor1, "rwm")
 	g.AddLinuxResourcesDevice(true, "b", &major2, &minor2, "rw")
 	g.AddLinuxResourcesDevice(true, "b", &major3, &minor3, "r")
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesDevices)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesDevices)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_memory.go
+++ b/validation/linux_cgroups_relative_memory.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -8,6 +9,11 @@ import (
 func main() {
 	var limit int64 = 50593792
 	var swappiness uint64 = 50
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -20,8 +26,8 @@ func main() {
 	g.SetLinuxResourcesMemoryKernelTCP(limit)
 	g.SetLinuxResourcesMemorySwappiness(swappiness)
 	g.SetLinuxResourcesMemoryDisableOOMKiller(true)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesMemory)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesMemory)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_network.go
+++ b/validation/linux_cgroups_relative_network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
@@ -8,6 +9,11 @@ import (
 func main() {
 	var id, prio uint32 = 255, 10
 	ifName := "lo"
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -15,8 +21,8 @@ func main() {
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesNetworkClassID(id)
 	g.AddLinuxResourcesNetworkPriorities(ifName, prio)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesNetwork)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesNetwork)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_cgroups_relative_pids.go
+++ b/validation/linux_cgroups_relative_pids.go
@@ -1,20 +1,26 @@
 package main
 
 import (
+	"github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/cgroups"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
 	var limit int64 = 1000
+
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
 	}
 	g.SetLinuxCgroupsPath(cgroups.RelCgroupPath)
 	g.SetLinuxResourcesPidsLimit(limit)
-	err = util.RuntimeOutsideValidate(g, util.ValidateLinuxResourcesPids)
+	err = util.RuntimeOutsideValidate(g, t, util.ValidateLinuxResourcesPids)
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
 }

--- a/validation/linux_ns_itype.go
+++ b/validation/linux_ns_itype.go
@@ -79,7 +79,7 @@ func testNamespaceInheritType(t *tap.T) error {
 	// We need to remove hostname to avoid test failures when not creating UTS namespace
 	g.RemoveHostname()
 
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		containerNsPath := fmt.Sprintf("/proc/%d/ns", state.Pid)
 
 		for _, nsName := range util.ProcNamespaces {

--- a/validation/linux_ns_nopath.go
+++ b/validation/linux_ns_nopath.go
@@ -80,7 +80,7 @@ func testNamespaceNoPath(t *tap.T) error {
 	g.AddLinuxUIDMapping(uint32(1000), uint32(0), uint32(1000))
 	g.AddLinuxGIDMapping(uint32(1000), uint32(0), uint32(1000))
 
-	err = util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	err = util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		containerNsPath := fmt.Sprintf("/proc/%d/ns", state.Pid)
 
 		for _, nsName := range util.ProcNamespaces {

--- a/validation/linux_ns_path.go
+++ b/validation/linux_ns_path.go
@@ -30,7 +30,7 @@ func waitForState(stateCheckFunc func() error) error {
 	}
 }
 
-func checkNamespacePath(unsharePid int, ns string) error {
+func checkNamespacePath(t *tap.T, unsharePid int, ns string) error {
 	testNsPath := fmt.Sprintf("/proc/%d/ns/%s", os.Getpid(), ns)
 	testNsInode, err := os.Readlink(testNsPath)
 	if err != nil {
@@ -92,7 +92,7 @@ func checkNamespacePath(unsharePid int, ns string) error {
 	rtns := util.GetRuntimeToolsNamespace(ns)
 	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
 
-	return util.RuntimeOutsideValidate(g, func(config *rspec.Spec, state *rspec.State) error {
+	return util.RuntimeOutsideValidate(g, t, func(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 		containerNsPath := fmt.Sprintf("/proc/%d/ns/%s", state.Pid, ns)
 		containerNsInode, err := os.Readlink(containerNsPath)
 		if err != nil {
@@ -129,7 +129,7 @@ func testNamespacePath(t *tap.T, ns string, unshareOpt string) error {
 		return fmt.Errorf("process failed to start")
 	}
 
-	return checkNamespacePath(cmd.Process.Pid, ns)
+	return checkNamespacePath(t, cmd.Process.Pid, ns)
 }
 
 func main() {

--- a/validation/linux_ns_path_type.go
+++ b/validation/linux_ns_path_type.go
@@ -25,7 +25,7 @@ func checkNSPathMatchType(t *tap.T, ns, wrongNs string) error {
 	rtns := util.GetRuntimeToolsNamespace(ns)
 	g.AddOrReplaceLinuxNamespace(rtns, unshareNsPath)
 
-	err = util.RuntimeOutsideValidate(g, nil)
+	err = util.RuntimeOutsideValidate(g, t, nil)
 
 	t.Ok(err != nil, fmt.Sprintf("got error when setting a wrong namespace path %q with type %s", unshareNsPath, rtns))
 	if err == nil {

--- a/validation/util/linux_resources_blkio.go
+++ b/validation/util/linux_resources_blkio.go
@@ -9,15 +9,11 @@ import (
 )
 
 // ValidateLinuxResourcesBlockIO validates linux.resources.blockIO.
-func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error {
-	t := tap.New()
-	t.Header(0)
-
+func ValidateLinuxResourcesBlockIO(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 	cg, err := cgroups.FindCgroup()
 	t.Ok((err == nil), "find blkio cgroup")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -25,13 +21,11 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 	t.Ok((err == nil), "get blkio cgroup data")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
 	if lbd.Weight == nil || config.Linux.Resources.BlockIO.Weight == nil {
 		t.Diagnostic(fmt.Sprintf("unable to get weight: lbd.Weight == %v, config.Linux.Resources.BlockIO.Weight == %v", lbd.Weight, config.Linux.Resources.BlockIO.Weight))
-		t.AutoPlan()
 		return nil
 	}
 
@@ -40,7 +34,6 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 
 	if lbd.LeafWeight == nil || config.Linux.Resources.BlockIO.LeafWeight == nil {
 		t.Diagnostic(fmt.Sprintf("unable to get leafWeight: lbd.LeafWeight == %v, config.Linux.Resources.BlockIO.LeafWeight == %v", lbd.LeafWeight, config.Linux.Resources.BlockIO.LeafWeight))
-		t.AutoPlan()
 		return nil
 	}
 
@@ -110,6 +103,5 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 		t.Ok(found, fmt.Sprintf("blkio write iops for %d:%d found", device.Major, device.Minor))
 	}
 
-	t.AutoPlan()
 	return nil
 }

--- a/validation/util/linux_resources_cpus.go
+++ b/validation/util/linux_resources_cpus.go
@@ -1,0 +1,137 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/mndrix/tap-go"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+)
+
+const (
+	// CPUCgroupPrefix is default path prefix where CPU cgroups are created
+	CPUCgroupPrefix string = "/sys/fs/cgroup/cpu,cpuacct"
+)
+
+// ValidateLinuxResourcesCPU validates if Linux.Resources.CPU is set to
+// correct values, the same as given values in the config.
+func ValidateLinuxResourcesCPU(config *rspec.Spec, t *tap.T, state *rspec.State) error {
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find cpu cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		return nil
+	}
+
+	lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get cpu cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		return nil
+	}
+
+	if lcd.Shares == nil || config.Linux.Resources.CPU.Shares == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu shares, lcd.Shares == %v, config.Linux.Resources.CPU.Shares == %v", lcd.Shares, config.Linux.Resources.CPU.Shares))
+		return nil
+	}
+	t.Ok(*lcd.Shares == *config.Linux.Resources.CPU.Shares, "cpu shares is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.CPU.Shares, *lcd.Shares)
+
+	if lcd.Period == nil || config.Linux.Resources.CPU.Period == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu period, lcd.Period == %v, config.Linux.Resources.CPU.Period == %v", lcd.Period, config.Linux.Resources.CPU.Period))
+		return nil
+	}
+	t.Ok(*lcd.Period == *config.Linux.Resources.CPU.Period, "cpu period is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.CPU.Period, *lcd.Period)
+
+	if lcd.Quota == nil || config.Linux.Resources.CPU.Quota == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu quota, lcd.Quota == %v, config.Linux.Resources.CPU.Quota == %v", lcd.Quota, config.Linux.Resources.CPU.Quota))
+		return nil
+	}
+	t.Ok(*lcd.Quota == *config.Linux.Resources.CPU.Quota, "cpu quota is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.CPU.Quota, *lcd.Quota)
+
+	t.Ok(lcd.Cpus == config.Linux.Resources.CPU.Cpus, "cpu cpus is set correctly")
+	t.Diagnosticf("expect: %s, actual: %s", config.Linux.Resources.CPU.Cpus, lcd.Cpus)
+
+	t.Ok(lcd.Mems == config.Linux.Resources.CPU.Mems, "cpu mems is set correctly")
+	t.Diagnosticf("expect: %s, actual: %s", config.Linux.Resources.CPU.Mems, lcd.Mems)
+
+	return nil
+}
+
+// ValidateLinuxResourcesCPUEmpty validates Linux.Resources.CPU is set to
+// correct values, when each value are set to the default ones.
+func ValidateLinuxResourcesCPUEmpty(config *rspec.Spec, t *tap.T, state *rspec.State) error {
+	outShares, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.shares"))
+	if err != nil {
+		return nil
+	}
+	sh, _ := strconv.Atoi(strings.TrimSpace(string(outShares)))
+	defaultShares := uint64(sh)
+
+	outPeriod, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_period_us"))
+	if err != nil {
+		return nil
+	}
+	pe, _ := strconv.Atoi(strings.TrimSpace(string(outPeriod)))
+	defaultPeriod := uint64(pe)
+
+	outQuota, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_quota_us"))
+	if err != nil {
+		return nil
+	}
+	qu, _ := strconv.Atoi(strings.TrimSpace(string(outQuota)))
+	defaultQuota := int64(qu)
+
+	defaultCpus := fmt.Sprintf("0-%d", runtime.NumCPU()-1)
+	defaultMems := "0"
+
+	cg, err := cgroups.FindCgroup()
+	t.Ok((err == nil), "find cpu cgroup")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		return nil
+	}
+
+	lcd, err := cg.GetCPUData(state.Pid, config.Linux.CgroupsPath)
+	t.Ok((err == nil), "get cpu cgroup data")
+	if err != nil {
+		t.Diagnostic(err.Error())
+		return nil
+	}
+
+	if lcd.Shares == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu shares, lcd.Shares == %v", lcd.Shares))
+		return nil
+	}
+	t.Ok(*lcd.Shares == defaultShares, "cpu shares is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", defaultShares, *lcd.Shares)
+
+	if lcd.Period == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu period, lcd.Period == %v", lcd.Period))
+		return nil
+	}
+	t.Ok(*lcd.Period == defaultPeriod, "cpu period is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", defaultPeriod, *lcd.Period)
+
+	if lcd.Quota == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get cpu quota, lcd.Quota == %v", lcd.Quota))
+		return nil
+	}
+	t.Ok(*lcd.Quota == defaultQuota, "cpu quota is set correctly")
+	t.Diagnosticf("expect: %d, actual: %d", defaultQuota, *lcd.Quota)
+
+	t.Ok(lcd.Cpus == defaultCpus, "cpu cpus is set correctly")
+	t.Diagnosticf("expect: %s, actual: %s", defaultCpus, lcd.Cpus)
+
+	t.Ok(lcd.Mems == defaultMems, "cpu mems is set correctly")
+	t.Diagnosticf("expect: %s, actual: %s", defaultMems, lcd.Mems)
+
+	return nil
+}

--- a/validation/util/linux_resources_devices.go
+++ b/validation/util/linux_resources_devices.go
@@ -10,15 +10,11 @@ import (
 )
 
 // ValidateLinuxResourcesDevices validates linux.resources.devices.
-func ValidateLinuxResourcesDevices(config *rspec.Spec, state *rspec.State) error {
-	t := tap.New()
-	t.Header(0)
-
+func ValidateLinuxResourcesDevices(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 	cg, err := cgroups.FindCgroup()
 	t.Ok((err == nil), "find devices")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -26,7 +22,6 @@ func ValidateLinuxResourcesDevices(config *rspec.Spec, state *rspec.State) error
 	t.Ok((err == nil), "get devices data")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -42,12 +37,10 @@ func ValidateLinuxResourcesDevices(config *rspec.Spec, state *rspec.State) error
 			if !found {
 				err := specerror.NewError(specerror.DevicesApplyInOrder, fmt.Errorf("The runtime MUST apply entries in the listed order"), rspec.Version)
 				t.Diagnostic(err.Error())
-				t.AutoPlan()
 				return nil
 			}
 		}
 	}
 
-	t.AutoPlan()
 	return nil
 }

--- a/validation/util/linux_resources_memory.go
+++ b/validation/util/linux_resources_memory.go
@@ -7,15 +7,11 @@ import (
 )
 
 // ValidateLinuxResourcesMemory validates linux.resources.memory.
-func ValidateLinuxResourcesMemory(config *rspec.Spec, state *rspec.State) error {
-	t := tap.New()
-	t.Header(0)
-
+func ValidateLinuxResourcesMemory(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 	cg, err := cgroups.FindCgroup()
 	t.Ok((err == nil), "find memory cgroup")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -23,7 +19,6 @@ func ValidateLinuxResourcesMemory(config *rspec.Spec, state *rspec.State) error 
 	t.Ok((err == nil), "get memory cgroup data")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -48,6 +43,5 @@ func ValidateLinuxResourcesMemory(config *rspec.Spec, state *rspec.State) error 
 	t.Ok(*lm.DisableOOMKiller == *config.Linux.Resources.Memory.DisableOOMKiller, "memory oom is set correctly")
 	t.Diagnosticf("expect: %t, actual: %t", *config.Linux.Resources.Memory.DisableOOMKiller, *lm.DisableOOMKiller)
 
-	t.AutoPlan()
 	return nil
 }

--- a/validation/util/linux_resources_network.go
+++ b/validation/util/linux_resources_network.go
@@ -9,15 +9,11 @@ import (
 )
 
 // ValidateLinuxResourcesNetwork validates linux.resources.network.
-func ValidateLinuxResourcesNetwork(config *rspec.Spec, state *rspec.State) error {
-	t := tap.New()
-	t.Header(0)
-
+func ValidateLinuxResourcesNetwork(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 	cg, err := cgroups.FindCgroup()
 	t.Ok((err == nil), "find network cgroup")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -25,7 +21,6 @@ func ValidateLinuxResourcesNetwork(config *rspec.Spec, state *rspec.State) error
 	t.Ok((err == nil), "get network cgroup data")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -44,6 +39,5 @@ func ValidateLinuxResourcesNetwork(config *rspec.Spec, state *rspec.State) error
 		t.Ok(found, fmt.Sprintf("network priority for %s found", priority.Name))
 	}
 
-	t.AutoPlan()
 	return nil
 }

--- a/validation/util/linux_resources_pids.go
+++ b/validation/util/linux_resources_pids.go
@@ -7,15 +7,11 @@ import (
 )
 
 // ValidateLinuxResourcesPids validates linux.resources.pids.
-func ValidateLinuxResourcesPids(config *rspec.Spec, state *rspec.State) error {
-	t := tap.New()
-	t.Header(0)
-
+func ValidateLinuxResourcesPids(config *rspec.Spec, t *tap.T, state *rspec.State) error {
 	cg, err := cgroups.FindCgroup()
 	t.Ok((err == nil), "find pids cgroup")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
@@ -23,13 +19,11 @@ func ValidateLinuxResourcesPids(config *rspec.Spec, state *rspec.State) error {
 	t.Ok((err == nil), "get pids cgroup data")
 	if err != nil {
 		t.Diagnostic(err.Error())
-		t.AutoPlan()
 		return nil
 	}
 
 	t.Ok(lpd.Limit == config.Linux.Resources.Pids.Limit, "pids limit is set correctly")
 	t.Diagnosticf("expect: %d, actual: %d", config.Linux.Resources.Pids.Limit, lpd.Limit)
 
-	t.AutoPlan()
 	return nil
 }

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -78,7 +78,7 @@ type LifecycleConfig struct {
 type PreFunc func(string) error
 
 // AfterFunc validate container's outside environment after created
-type AfterFunc func(config *rspec.Spec, state *rspec.State) error
+type AfterFunc func(config *rspec.Spec, t *tap.T, state *rspec.State) error
 
 func init() {
 	runtimeInEnv := os.Getenv("RUNTIME")
@@ -240,7 +240,7 @@ func RuntimeInsideValidate(g *generate.Generator, f PreFunc) (err error) {
 }
 
 // RuntimeOutsideValidate validate runtime outside a container.
-func RuntimeOutsideValidate(g *generate.Generator, f AfterFunc) error {
+func RuntimeOutsideValidate(g *generate.Generator, t *tap.T, f AfterFunc) error {
 	bundleDir, err := PrepareBundle()
 	if err != nil {
 		return err
@@ -276,7 +276,7 @@ func RuntimeOutsideValidate(g *generate.Generator, f AfterFunc) error {
 		if err != nil {
 			return err
 		}
-		if err := f(g.Spec(), &state); err != nil {
+		if err := f(g.Spec(), t, &state); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR tries to cover more test cases by running cgroup tests with different combinations of input values. Also it tries to print out detailed output results in the TAP format.

To do that, first of all, we change prototype of `RuntimeOutsideValidate()` as well as `AfterFunc()`, updating all corresponding call sites. And then we update cgroups tests. Changed cgroups tests are:

* Memory 
* CPU
* Network
* Blkio
* HugeTLB

Especially I needed to update CPU cgroups tests a lot, by following the same semantics of memory cgroups. For that, I had to add helpers in `validation/util/linux_resources_cpus.go`.

/cc @alban 
