### PR TITLE
validation: fix nil deferences in cpu & blkio cgroups tests

### DIFF
--- a/validation/linux_cgroups_cpus.go
+++ b/validation/linux_cgroups_cpus.go
@@ -32,11 +32,23 @@ func main() {
 		if err != nil {
 			return err
 		}
+
+		if lcd.Shares == nil {
+			return fmt.Errorf("unable to get cpu shares, lcd.Shares == %v", lcd.Shares)
+		}
 		if *lcd.Shares != shares {
 			return fmt.Errorf("cpus shares limit is not set correctly, expect: %d, actual: %d", shares, *lcd.Shares)
 		}
+
+		if lcd.Quota == nil {
+			return fmt.Errorf("unable to get cpu quota, lcd.Quota == %v", lcd.Quota)
+		}
 		if *lcd.Quota != quota {
 			return fmt.Errorf("cpus quota is not set correctly, expect: %d, actual: %d", quota, *lcd.Quota)
+		}
+
+		if lcd.Period == nil {
+			return fmt.Errorf("unable to get cpu period, lcd.Period == %v", lcd.Period)
 		}
 		if *lcd.Period != period {
 			return fmt.Errorf("cpus period is not set correctly, expect: %d, actual: %d", period, *lcd.Period)

--- a/validation/util/linux_resources_blkio.go
+++ b/validation/util/linux_resources_blkio.go
@@ -29,8 +29,20 @@ func ValidateLinuxResourcesBlockIO(config *rspec.Spec, state *rspec.State) error
 		return nil
 	}
 
+	if lbd.Weight == nil || config.Linux.Resources.BlockIO.Weight == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get weight: lbd.Weight == %v, config.Linux.Resources.BlockIO.Weight == %v", lbd.Weight, config.Linux.Resources.BlockIO.Weight))
+		t.AutoPlan()
+		return nil
+	}
+
 	t.Ok(*lbd.Weight == *config.Linux.Resources.BlockIO.Weight, "blkio weight is set correctly")
 	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.Weight, *lbd.Weight)
+
+	if lbd.LeafWeight == nil || config.Linux.Resources.BlockIO.LeafWeight == nil {
+		t.Diagnostic(fmt.Sprintf("unable to get leafWeight: lbd.LeafWeight == %v, config.Linux.Resources.BlockIO.LeafWeight == %v", lbd.LeafWeight, config.Linux.Resources.BlockIO.LeafWeight))
+		t.AutoPlan()
+		return nil
+	}
 
 	t.Ok(*lbd.LeafWeight == *config.Linux.Resources.BlockIO.LeafWeight, "blkio leafWeight is set correctly")
 	t.Diagnosticf("expect: %d, actual: %d", *config.Linux.Resources.BlockIO.LeafWeight, *lbd.LeafWeight)


### PR DESCRIPTION
Fix several nil dereference errors in validation tests for cpu & blkio cgroups, such as:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6eee8b]

goroutine 1 [running]:
github.com/opencontainers/runtime-tools/validation/util.ValidateLinuxResourcesBlockIO(0xc420264070,
0xc420248a50, 0x5, 0xc42027e540)
        /home/vagrant/go/src/github.com/opencontainers/runtime-tools/validation/util/linux_resources_blkio.go:37 +0x2bb
github.com/opencontainers/runtime-tools/validation/util.RuntimeOutsideValidate(0xc4200102b0, 0x7c1c00, 0x0, 0x0)
        /home/vagrant/go/src/github.com/opencontainers/runtime-tools/validation/util/test.go:279 +0x397
main.testEmptyBlkio(0x0, 0x0)
        /home/vagrant/go/src/github.com/opencontainers/runtime-tools/validation/linux_cgroups_blkio.go:68 +0x19e
main.main()
        /home/vagrant/go/src/github.com/opencontainers/runtime-tools/validation/linux_cgroups_blkio.go:88 +0x8c
```

Note that this PR fixes only a part of potential nil dereferences in validation tests. It only touches cpu and blkio, which were discovered during testing the PR https://github.com/opencontainers/runtime-tools/pull/637.

/cc @Mashimiao 
Signed-off-by: Dongsu Park <dongsu@kinvolk.io>