### PR TITLE
validation: fix nil dereference when handling multierror in hooks_stdin

### DIFF
--- a/validation/hooks_stdin.go
+++ b/validation/hooks_stdin.go
@@ -151,7 +151,13 @@ func main() {
 	}
 	for _, file := range []string{"prestart", "poststart", "poststop"} {
 		errs := stdinStateCheck(outputDir, file, expectedState)
-		util.SpecErrorOK(t, errs.ErrorOrNil() == nil, specerror.NewError(specerror.PosixHooksStateToStdin, fmt.Errorf("the state of the container MUST be passed to %q hook over stdin", file), rspecs.Version), errors.New(errs.Error()))
+		var newError error
+		if errs == nil {
+			newError = errors.New("")
+		} else {
+			newError = errors.New(errs.Error())
+		}
+		util.SpecErrorOK(t, errs.ErrorOrNil() == nil, specerror.NewError(specerror.PosixHooksStateToStdin, fmt.Errorf("the state of the container MUST be passed to %q hook over stdin", file), rspecs.Version), newError)
 	}
 
 	t.AutoPlan()


### PR DESCRIPTION
As `stdinStateCheck()` can return nil for errs, we need to access to `errs.Error()` only when errs is not nil. So conditionally compose newError for both cases, errs == nil and errs != nil, to avoid panics like that:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4f5a02]

goroutine 1 [running]:
github.com/opencontainers/runtime-tools/vendor/github.com/hashicorp/go-multierror.(*Error).Error(0x0, 0x7dfc20, 0xc420224480)
	.../github.com/opencontainers/runtime-tools/vendor/github.com/hashicorp/go-multierror/multierror.go:15 +0x22
main.main()
	.../github.com/opencontainers/runtime-tools/validation/hooks_stdin.go:154 +0x11ba
```

Signed-off-by: Dongsu Park <dongsu@kinvolk.io>