### PR TITLE
validation: add minor checks for ptmx and kill signal

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -50,8 +50,12 @@ var (
 		"/dev/shm": "tmpfs",
 	}
 
+	// NOTE: check if /dev/ptmx is a symlink to /dev/pts/ptmx.
+	// os.Readlink() returns only a relative path "pts/ptmx" instead of
+	// an absolute path /dev/pts/ptmx.
 	defaultSymlinks = map[string]string{
 		"/dev/fd":     "/proc/self/fd",
+		"/dev/ptmx":   "pts/ptmx",
 		"/dev/stdin":  "/proc/self/fd/0",
 		"/dev/stdout": "/proc/self/fd/1",
 		"/dev/stderr": "/proc/self/fd/2",

--- a/validation/killsig.go
+++ b/validation/killsig.go
@@ -15,6 +15,8 @@ import (
 
 var signals = []string{
 	"TERM",
+	"USR1",
+	"USR2",
 }
 
 func main() {


### PR DESCRIPTION
Inside a container, we need to check if `/dev/ptmx` exists, a symlink to `/dev/pts/ptmx`, as mentioned in the [runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#default-devices).

Also in `validation/killsig.t`, Test not only SIGTERM, but also SIGUSR1 as well as SIGUSR2.

