### PR TITLE
validation: add more test cases for masked paths tests

### DIFF
--- a/validation/linux_masked_paths.go
+++ b/validation/linux_masked_paths.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/opencontainers/runtime-tools/validation/util"
+	"golang.org/x/sys/unix"
 )
 
 func checkMaskedPaths() error {
@@ -120,6 +121,30 @@ func checkMaskedSymlinks() error {
 	return fmt.Errorf("expected: err != nil, actual: err == nil")
 }
 
+func checkMaskedDeviceNodes(mode uint32) error {
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		return err
+	}
+
+	maskedDevice := "/masked-device"
+
+	g.AddLinuxMaskedPaths(maskedDevice)
+	return util.RuntimeInsideValidate(g, func(path string) error {
+		testFile := filepath.Join(path, maskedDevice)
+
+		if err := unix.Mknod(testFile, mode, 0); err != nil {
+			return err
+		}
+
+		if _, err := os.Stat(testFile); err != nil && os.IsNotExist(err) {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func main() {
 	if err := checkMaskedPaths(); err != nil {
 		util.Fatal(err)
@@ -131,5 +156,19 @@ func main() {
 
 	if err := checkMaskedSymlinks(); err != nil {
 		util.Fatal(err)
+	}
+
+	// test creation of different type of devices, i.e. block device,
+	// character device, and FIFO.
+	modes := []uint32{
+		unix.S_IFBLK | 0666,
+		unix.S_IFCHR | 0666,
+		unix.S_IFIFO | 0666,
+	}
+
+	for _, m := range modes {
+		if err := checkMaskedDeviceNodes(m); err != nil {
+			util.Fatal(err)
+		}
 	}
 }

--- a/validation/linux_masked_paths.go
+++ b/validation/linux_masked_paths.go
@@ -61,8 +61,36 @@ func checkMaskedPaths() error {
 	return err
 }
 
+func checkMaskedRelPaths() error {
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		return err
+	}
+
+	// Deliberately set a relative path to be masked, and expect an error
+	maskedRelPath := "masked-relpath"
+
+	g.AddLinuxMaskedPaths(maskedRelPath)
+	err = util.RuntimeInsideValidate(g, func(path string) error {
+		testFile := filepath.Join(path, maskedRelPath)
+		if _, err := os.Stat(testFile); err != nil && os.IsNotExist(err) {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+	return fmt.Errorf("expected: err != nil, actual: err == nil")
+}
+
 func main() {
 	if err := checkMaskedPaths(); err != nil {
+		util.Fatal(err)
+	}
+
+	if err := checkMaskedRelPaths(); err != nil {
 		util.Fatal(err)
 	}
 }


### PR DESCRIPTION
Split out the test function into `checkMaskedPaths()`, and add more cases for masked paths like subdirectory, file under subdirectory, and directory under subdirectory.

Test inside container should return error if a relative path is given for masked paths.

Deliberately create an invalid symlink that points out of the container, to see if the test fails inside the container.

Create masked block device, char device, and fifo, to check if they are masked as expected.
