### PR TITLE
mountinfo: parse empty strings in source

### DIFF
--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -44,7 +44,7 @@ func FindCgroup() (Cgroup, error) {
 		fields := strings.Split(text, " ")
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
-		postSeparatorFields := strings.Fields(text[index+3:])
+		postSeparatorFields := strings.Split(text[index+3:], " ")
 		numPostFields := len(postSeparatorFields)
 
 		// This is an error as we can't detect if the mount is for "cgroup"
@@ -53,10 +53,7 @@ func FindCgroup() (Cgroup, error) {
 		}
 
 		if postSeparatorFields[0] == "cgroup" {
-			// Check that the mount is properly formated.
-			if numPostFields < 3 {
-				return nil, fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
-			}
+			// No need to parse the rest of the postSeparatorFields
 
 			cg := &CgroupV1{
 				MountPath: filepath.Dir(fields[4]),

--- a/cmd/runtimetest/mount/mountinfo_linux.go
+++ b/cmd/runtimetest/mount/mountinfo_linux.go
@@ -64,7 +64,7 @@ func parseInfoFile(r io.Reader) ([]*Info, error) {
 		}
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
-		postSeparatorFields := strings.Fields(text[index+3:])
+		postSeparatorFields := strings.Split(text[index+3:], " ")
 		if len(postSeparatorFields) < 3 {
 			return nil, fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
 		}


### PR DESCRIPTION
The source of a mount in /proc/self/mountinfo can unfortunately be an
empty string. Before this patch, 'mount' and 'mountpoint' fail as
following:
```
  $ sudo mount -t tmpfs "" /tmp/bb
  $ mount
  mount: /proc/self/mountinfo: parse error at line 64 -- ignored
  $ mountpoint /tmp/bb
  /tmp/bb is not a mountpoint
```
This patch fixes the parsing.

Signed-off-by: Alban Crequy <alban@kinvolk.io>

-----

Similar patch in util-linux: https://www.spinics.net/lists/linux-fsdevel/msg128896.html
Similar PR in runc: https://github.com/opencontainers/runc/pull/1829
Related patch that would fix this kernel-side: https://patchwork.kernel.org/patch/10349095/
