### PR TITLE
add resource validation after delete

### DIFF
--- a/validation/delete_only_create_resources/delete_only_create_resources.go
+++ b/validation/delete_only_create_resources/delete_only_create_resources.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	tap "github.com/mndrix/tap-go"
+	"github.com/mrunalp/fileutils"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/specerror"
+	"github.com/opencontainers/runtime-tools/validation/util"
+	uuid "github.com/satori/go.uuid"
+)
+
+func main() {
+	t := tap.New()
+	t.Header(0)
+
+	// Create a cgroup
+	cgPath := "/sys/fs/cgroup"
+	testPath := filepath.Join(cgPath, "pids", "cgrouptest")
+	os.Mkdir(testPath, 0755)
+	defer os.RemoveAll(testPath)
+
+	bundleDir, err := util.PrepareBundle()
+	if err != nil {
+		util.Fatal(err)
+	}
+	defer os.RemoveAll(bundleDir)
+
+	r, err := util.NewRuntime(util.RuntimeCommand, bundleDir)
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	r.SetID(uuid.NewV4().String())
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = r.SetConfig(g)
+	if err != nil {
+		util.Fatal(err)
+	}
+	err = fileutils.CopyFile("runtimetest", filepath.Join(r.BundleDir, "runtimetest"))
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = r.Create()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	state, err := r.State()
+	if err != nil {
+		util.Fatal(err)
+	}
+	// Add the container to the cgroup
+	err = ioutil.WriteFile(filepath.Join(testPath, "tasks"), []byte(strconv.Itoa(state.Pid)), 0644)
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = r.Start()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = util.WaitingForStatus(r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
+	if err == nil {
+		err = r.Delete()
+	}
+	if err != nil {
+		t.Fail(err.Error())
+	}
+
+	_, err = os.Stat(testPath)
+	fmt.Println(err)
+	util.SpecErrorOK(t, err == nil, specerror.NewError(specerror.DeleteOnlyCreatedRes, fmt.Errorf("Note that resources associated with the container, but not created by this container, MUST NOT be deleted"), rspec.Version), nil)
+
+	t.AutoPlan()
+}

--- a/validation/delete_resources/delete_resources.go
+++ b/validation/delete_resources/delete_resources.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	tap "github.com/mndrix/tap-go"
+	"github.com/mrunalp/fileutils"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-tools/cgroups"
+	"github.com/opencontainers/runtime-tools/specerror"
+	"github.com/opencontainers/runtime-tools/validation/util"
+	uuid "github.com/satori/go.uuid"
+)
+
+func main() {
+	t := tap.New()
+	t.Header(0)
+
+	bundleDir, err := util.PrepareBundle()
+	if err != nil {
+		util.Fatal(err)
+	}
+	defer os.RemoveAll(bundleDir)
+
+	r, err := util.NewRuntime(util.RuntimeCommand, bundleDir)
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	r.SetID(uuid.NewV4().String())
+	g, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	var limit int64 = 1000
+
+	g.SetLinuxCgroupsPath(cgroups.AbsCgroupPath)
+	g.SetLinuxResourcesPidsLimit(limit)
+
+	err = r.SetConfig(g)
+	if err != nil {
+		util.Fatal(err)
+	}
+	err = fileutils.CopyFile("runtimetest", filepath.Join(r.BundleDir, "runtimetest"))
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = r.Create()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	state, err := r.State()
+	if err != nil {
+		util.Fatal(err)
+	}
+	if err := util.ValidateLinuxResourcesPids(g.Spec(), t, &state); err != nil {
+		util.Fatal(err)
+	}
+
+	err = r.Start()
+	if err != nil {
+		util.Fatal(err)
+	}
+
+	err = util.WaitingForStatus(r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
+	if err == nil {
+		err = r.Delete()
+	}
+	if err != nil {
+		t.Fail(err.Error())
+	}
+
+	path := filepath.Join("/sys/fs/cgroup/pids", cgroups.AbsCgroupPath)
+	_, err = os.Stat(path)
+	util.SpecErrorOK(t, os.IsNotExist(err), specerror.NewError(specerror.DeleteResImplement, fmt.Errorf("Deleting a container MUST delete the resources that were created during the `create` step"), rspec.Version), nil)
+
+	t.AutoPlan()
+}


### PR DESCRIPTION
```
DeleteResImplement: Deleting a container MUST delete the resources that were created during the create step.
DeleteOnlyCreatedRes: Note that resources associated with the container, but not created by this container, MUST NOT be deleted.
```
At present, `DeleteResImplement` is implemented, but it is not yet clear how to implement `DeleteOnlyCreatedRes`. (Write the container id to the existing `cgroup tasks`?)
@liangchenye @dongsupark @wking WDYT?


Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>