### PR TITLE
validation: mounts: fix condition of source & type check

### DIFF
--- a/validation/mounts/mounts.go
+++ b/validation/mounts/mounts.go
@@ -6,22 +6,85 @@ import (
 )
 
 func main() {
+	defaultOptions := []string{
+		"nosuid",
+		"strictatime",
+		"mode=755",
+		"size=1k",
+	}
+
+	// Different combinations of mount types, mount options, mount propagation modes
+	mounts := []rspec.Mount{
+		rspec.Mount{
+			Destination: "/tmp/test-shared",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"shared"},
+		},
+		rspec.Mount{
+			Destination: "/tmp/test-slave",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"slave"},
+		},
+		rspec.Mount{
+			Destination: "/tmp/test-private",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"private"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-shared",
+			Source:      "/etc",
+			Options:     []string{"bind", "shared"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-rshared",
+			Source:      "/etc",
+			Options:     []string{"rbind", "rshared"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-slave",
+			Source:      "/etc",
+			Options:     []string{"bind", "slave"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-rslave",
+			Source:      "/etc",
+			Options:     []string{"rbind", "rslave"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-private",
+			Source:      "/etc",
+			Options:     []string{"bind", "private"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-rprivate",
+			Source:      "/etc",
+			Options:     []string{"rbind", "rprivate"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-unbindable",
+			Source:      "/etc",
+			Options:     []string{"bind", "unbindable"},
+		},
+		rspec.Mount{
+			Destination: "/mnt/etc-runbindable",
+			Source:      "/etc",
+			Options:     []string{"rbind", "runbindable"},
+		},
+	}
+
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
 	}
-	mount := rspec.Mount{
-		Destination: "/tmp",
-		Type:        "tmpfs",
-		Source:      "tmpfs",
-		Options: []string{
-			"nosuid",
-			"strictatime",
-			"mode=755",
-			"size=1k",
-		},
+
+	for _, m := range mounts {
+		m.Options = append(defaultOptions, m.Options...)
+
+		g.AddMount(m)
 	}
-	g.AddMount(mount)
 	err = util.RuntimeInsideValidate(g, nil, nil)
 	if err != nil {
 		util.Fatal(err)


### PR DESCRIPTION
The runtime-spec says that [mount source is optional](https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#mounts). So let's relax condition of the mount source path check, so that it only checks for an empty mount source. Ditto for the type field.

The 'mount' test now tries different mount options: bind and not bind, recursive or not, different mount propagation modes.

runc passes the test after https://github.com/opencontainers/runc/pull/1845

Closes: https://github.com/opencontainers/runtime-tools/issues/651

Based on work from: Dongsu Park <dongsu@kinvolk.io> @dongsupark 
Signed-off-by: Alban Crequy <alban@kinvolk.io>