### PR TITLE
generate: add short options

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -20,7 +20,7 @@ import (
 
 var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "args", Usage: "command to run in the container"},
-	cli.StringSliceFlag{Name: "env", Usage: "add environment variable e.g. key=value"},
+	cli.StringSliceFlag{Name: "env, e", Usage: "add environment variable e.g. key=value"},
 	cli.StringSliceFlag{Name: "env-file", Usage: "read in a file of environment variables"},
 	cli.StringSliceFlag{Name: "hooks-poststart-add", Usage: "set command to run in poststart hooks"},
 	cli.BoolFlag{Name: "hooks-poststart-remove-all", Usage: "remove all poststart hooks"},
@@ -29,7 +29,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "hooks-prestart-add", Usage: "set command to run in prestart hooks"},
 	cli.BoolFlag{Name: "hooks-prestart-remove-all", Usage: "remove all prestart hooks"},
 	cli.StringFlag{Name: "hostname", Usage: "hostname value for the container"},
-	cli.StringSliceFlag{Name: "label", Usage: "add annotations to the configuration e.g. key=value"},
+	cli.StringSliceFlag{Name: "label, l", Usage: "add annotations to the configuration e.g. key=value"},
 	cli.StringFlag{Name: "linux-apparmor", Usage: "specifies the the apparmor profile for the container"},
 	cli.IntFlag{Name: "linux-blkio-leaf-weight", Usage: "Block IO (relative leaf weight), the range is from 10 to 1000"},
 	cli.StringSliceFlag{Name: "linux-blkio-leaf-weight-device", Usage: "Block IO (relative device leaf weight), e.g. major:minor:leaf-weight"},

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -308,12 +308,14 @@ _oci-runtime-tool_generate() {
 	local options_with_args="
 		--args
 		--env
+		-e
 		--env-file
 		--hooks-poststart-add
 		--hooks-poststop-add
 		--hooks-prestart-add
 		--hostname
 		--label
+		-l
 		--linux-apparmor
 		--linux-blkio-leaf-weight
 		--linux-blkio-leaf-weight-device

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -22,7 +22,7 @@ read the configuration from `config.json`.
 
   --args "/usr/bin/httpd" --args "-D" --args "FOREGROUND"
 
-**--env**=[]
+**--env, -e**=[]
   Set environment variables e.g. key=value.
   This option allows you to specify arbitrary environment variables
   that are available for the process that will be launched inside of
@@ -87,7 +87,7 @@ read the configuration from `config.json`.
   When specifed with --hooks-prestart-add, will be applied first and then add
   new prestart hooks.
 
-**--label**=[]
+**--label, -l**=[]
   Add annotations to the configuration e.g. key=value.
   Currently, key containing equals sign is not supported.
 


### PR DESCRIPTION
For easier use, add short options to `env` and `label` option.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>