### PR TITLE
/proc should be mounted with nosuid, noexec, nodev to match the host

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -162,7 +162,7 @@ func New(os string) (generator Generator, err error) {
 				Destination: "/proc",
 				Type:        "proc",
 				Source:      "proc",
-				Options:     nil,
+				Options:     []string{"nosuid", "noexec", "nodev"},
 			},
 			{
 				Destination: "/dev",


### PR DESCRIPTION
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>