### PR TITLE
readme: fix wrong filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ make: *** [Makefile:44: localvalidation] Error 1
 You can also run an individual test executable directly:
 
 ```console
-$ RUNTIME=runc validation/default.t
+$ sudo RUNTIME=runc validation/default/default.t
 TAP version 13
 ok 1 - has expected hostname
   ---
@@ -105,7 +105,7 @@ If you cannot install node-tap, you can probably run the test suite with another
 For example, with [`prove`][prove]:
 
 ```console
-$ sudo make TAP='prove -Q -j9' RUNTIME=runc VALIDATION_TESTS=validation/pidfile.t localvalidation
+$ sudo make TAP='prove -Q -j9' RUNTIME=runc VALIDATION_TESTS=validation/pidfile/pidfile.t localvalidation
 RUNTIME=runc prove -Q -j9 validation/pidfile.t
 All tests successful.
 Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.03 cusr  0.03 csys =  0.08 CPU)


### PR DESCRIPTION
Signed-off-by: Ace-Tang <aceapril@126.com>

fix `validation/default.t` path wrong in readme.