### PR TITLE
generate: add process-cap-add and process-cap-drop option

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -94,6 +94,7 @@ var generateFlags = []cli.Flag{
 	cli.StringFlag{Name: "os", Value: runtime.GOOS, Usage: "operating system the container is created for"},
 	cli.StringFlag{Name: "output", Usage: "output file (defaults to stdout)"},
 	cli.BoolFlag{Name: "privileged", Usage: "enable privileged container settings"},
+	cli.StringFlag{Name: "process-cap-add", Usage: "add Linux capabilities to all 5 capability sets"},
 	cli.StringFlag{Name: "process-cap-add-ambient", Usage: "add Linux ambient capabilities"},
 	cli.StringFlag{Name: "process-cap-add-bounding", Usage: "add Linux bounding capabilities"},
 	cli.StringFlag{Name: "process-cap-add-effective", Usage: "add Linux effective capabilities"},
@@ -337,6 +338,16 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 
 	if context.Bool("process-cap-drop-all") {
 		g.ClearProcessCapabilities()
+	}
+
+	if context.IsSet("process-cap-add") {
+		addCaps := context.String("process-cap-add")
+		parts := strings.Split(addCaps, ",")
+		for _, part := range parts {
+			if err := g.AddProcessCapability(part); err != nil {
+				return err
+			}
+		}
 	}
 
 	if context.IsSet("process-cap-add-ambient") {

--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -100,6 +100,7 @@ var generateFlags = []cli.Flag{
 	cli.StringFlag{Name: "process-cap-add-effective", Usage: "add Linux effective capabilities"},
 	cli.StringFlag{Name: "process-cap-add-inheritable", Usage: "add Linux inheritable capabilities"},
 	cli.StringFlag{Name: "process-cap-add-permitted", Usage: "add Linux permitted capabilities"},
+	cli.StringFlag{Name: "process-cap-drop", Usage: "drop Linux capabilities to all 5 capability sets"},
 	cli.BoolFlag{Name: "process-cap-drop-all", Usage: "drop all Linux capabilities"},
 	cli.StringFlag{Name: "process-cap-drop-ambient", Usage: "drop Linux ambient capabilities"},
 	cli.StringFlag{Name: "process-cap-drop-bounding", Usage: "drop Linux bounding capabilities"},
@@ -395,6 +396,16 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		parts := strings.Split(addCaps, ",")
 		for _, part := range parts {
 			if err := g.AddProcessCapabilityPermitted(part); err != nil {
+				return err
+			}
+		}
+	}
+
+	if context.IsSet("process-cap-drop") {
+		addCaps := context.String("process-cap-drop")
+		parts := strings.Split(addCaps, ",")
+		for _, part := range parts {
+			if err := g.DropProcessCapability(part); err != nil {
 				return err
 			}
 		}

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -377,6 +377,7 @@ _oci-runtime-tool_generate() {
 		--process-cap-add-effective
 		--process-cap-add-inheritable
 		--process-cap-add-permitted
+		--process-cap-drop
 		--process-cap-drop-ambient
 		--process-cap-drop-bounding
 		--process-cap-drop-effective

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -371,6 +371,7 @@ _oci-runtime-tool_generate() {
 		--mounts-remove
 		--os
 		--output
+		--process-cap-add
 		--process-cap-add-ambient
 		--process-cap-add-bounding
 		--process-cap-add-effective

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1074,6 +1074,69 @@ func (g *Generator) ClearProcessCapabilities() {
 	g.Config.Process.Capabilities.Ambient = []string{}
 }
 
+// AddProcessCapability adds a process capability into all 5 capability sets.
+func (g *Generator) AddProcessCapability(c string) error {
+	cp := strings.ToUpper(c)
+	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+		return err
+	}
+
+	g.initConfigProcessCapabilities()
+
+	var foundAmbient, foundBounding, foundEffective, foundInheritable, foundPermitted bool
+	for _, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			foundAmbient = true
+			break
+		}
+	}
+	if !foundAmbient {
+		g.Config.Process.Capabilities.Ambient = append(g.Config.Process.Capabilities.Ambient, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			foundBounding = true
+			break
+		}
+	}
+	if !foundBounding {
+		g.Config.Process.Capabilities.Bounding = append(g.Config.Process.Capabilities.Bounding, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			foundEffective = true
+			break
+		}
+	}
+	if !foundEffective {
+		g.Config.Process.Capabilities.Effective = append(g.Config.Process.Capabilities.Effective, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			foundInheritable = true
+			break
+		}
+	}
+	if !foundInheritable {
+		g.Config.Process.Capabilities.Inheritable = append(g.Config.Process.Capabilities.Inheritable, cp)
+	}
+
+	for _, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			foundPermitted = true
+			break
+		}
+	}
+	if !foundPermitted {
+		g.Config.Process.Capabilities.Permitted = append(g.Config.Process.Capabilities.Permitted, cp)
+	}
+
+	return nil
+}
+
 // AddProcessCapabilityAmbient adds a process capability into g.Config.Process.Capabilities.Ambient.
 func (g *Generator) AddProcessCapabilityAmbient(c string) error {
 	cp := strings.ToUpper(c)

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1253,6 +1253,42 @@ func (g *Generator) AddProcessCapabilityPermitted(c string) error {
 	return nil
 }
 
+// DropProcessCapability drops a process capability from all 5 capability sets.
+func (g *Generator) DropProcessCapability(c string) error {
+	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {
+		return nil
+	}
+
+	cp := strings.ToUpper(c)
+	for i, cap := range g.Config.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Ambient = removeFunc(g.Config.Process.Capabilities.Ambient, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Bounding = removeFunc(g.Config.Process.Capabilities.Bounding, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Effective = removeFunc(g.Config.Process.Capabilities.Effective, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Inheritable = removeFunc(g.Config.Process.Capabilities.Inheritable, i)
+		}
+	}
+	for i, cap := range g.Config.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			g.Config.Process.Capabilities.Permitted = removeFunc(g.Config.Process.Capabilities.Permitted, i)
+		}
+	}
+
+	return validate.CapValid(cp, false)
+}
+
 // DropProcessCapabilityAmbient drops a process capability from g.Config.Process.Capabilities.Ambient.
 func (g *Generator) DropProcessCapabilityAmbient(c string) error {
 	if g.Config == nil || g.Config.Process == nil || g.Config.Process.Capabilities == nil {

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -372,6 +372,11 @@ read the configuration from `config.json`.
 
   When the operator executes **oci-runtime-tool generate --privileged**, OCI will enable access to all devices on the host as well as disable some of the confinement mechanisms like AppArmor, SELinux, and seccomp from blocking access to privileged processes.  This gives the container processes nearly all the same access to the host as processes generating outside of a container on the host.
 
+**--process-cap-add**=[]
+  Add Linux capabilities to all 5 capability sets.
+  You can use this command to add multiple capabilities. Each value should be used ',' separated.
+  e.g. --process-cap-add CAP_FOWNER,CAP_FSETID
+
 **--process-cap-add-ambient**=[]
   Add Linux ambient capabilities.
   You can use this command to add multiple capabilities. Each value should be used ',' separated.

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -402,6 +402,11 @@ read the configuration from `config.json`.
   You can use this command to add multiple capabilities. Each value should be used ',' separated.
   e.g. --process-cap-add-permitted CAP_FOWNER,CAP_FSETID
 
+**--process-cap-drop**=[]
+  Drop Linux capabilities to all 5 capability sets.
+  You can use this command to drop multiple capabilities. Each value should be used ',' separated.
+  e.g. --process-cap-drop CAP_FOWNER,CAP_FSETID
+
 **--process-cap-drop-all**=true|false
   Drop all Linux capabilities
   This option conflicts with other cap options, as --process-cap-*.


### PR DESCRIPTION
Add process-cap-add option to add Linux capabilities to all 5 capability sets.

```
oci-runtime-tool generate --process-cap-add CAP_FOWNER,CAP_FSETID
```

Add process-cap-drop option to drop Linux capabilities to all 5 capability sets.

```
oci-runtime-tool generate --process-cap-drop CAP_FOWNER,CAP_FSETID
```