### PR TITLE
fix up vm parameters

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/opencontainers/runtime-tools",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v79",
+	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
 	],
@@ -34,8 +34,8 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
-			"Comment": "v1.0.1-44-g6f5fcd4",
-			"Rev": "6f5fcd44f6978a021f1d4828d3e088d79221b241"
+			"Comment": "v1.0.1-57-g1722abf",
+			"Rev": "1722abf79c2f8f2675f47367f827c6491472cf27"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -128,12 +128,12 @@ var generateFlags = []cli.Flag{
 	cli.StringFlag{Name: "solaris-max-shm-memory", Usage: "Specifies the maximum amount of shared memory"},
 	cli.StringFlag{Name: "solaris-milestone", Usage: "Specifies the SMF FMRI"},
 	cli.StringFlag{Name: "template", Usage: "base template to use for creating the configuration"},
-	cli.StringFlag{Name: "vm-hypervisor-parameters", Usage: "specifies an array of parameters to pass to the hypervisor"},
+	cli.StringSliceFlag{Name: "vm-hypervisor-parameters", Usage: "specifies an array of parameters to pass to the hypervisor"},
 	cli.StringFlag{Name: "vm-hypervisor-path", Usage: "specifies the path to the hypervisor binary that manages the container virtual machine"},
 	cli.StringFlag{Name: "vm-image-format", Usage: "set the format of the container virtual machine root image"},
 	cli.StringFlag{Name: "vm-image-path", Usage: "set path to the container virtual machine root image"},
 	cli.StringFlag{Name: "vm-kernel-initrd", Usage: "set path to an initial ramdisk to be used by the container virtual machine"},
-	cli.StringFlag{Name: "vm-kernel-parameters", Usage: "specifies an array of parameters to pass to the kernel"},
+	cli.StringSliceFlag{Name: "vm-kernel-parameters", Usage: "specifies an array of parameters to pass to the kernel"},
 	cli.StringFlag{Name: "vm-kernel-path", Usage: "set path to the kernel used to boot the container virtual machine"},
 	cli.StringSliceFlag{Name: "windows-devices", Usage: "specifies a list of devices to be mapped into the container"},
 	cli.StringFlag{Name: "windows-hyperv-utilityVMPath", Usage: "specifies the path to the image used for the utility VM"},
@@ -899,7 +899,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	}
 
 	if context.IsSet("vm-hypervisor-parameters") {
-		g.SetVMHypervisorParameters(context.String("vm-hypervisor-parameters"))
+		g.SetVMHypervisorParameters(context.StringSlice("vm-hypervisor-parameters"))
 	}
 
 	if context.IsSet("vm-kernel-path") {
@@ -909,7 +909,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	}
 
 	if context.IsSet("vm-kernel-parameters") {
-		g.SetVMKernelParameters(context.String("vm-kernel-parameters"))
+		g.SetVMKernelParameters(context.StringSlice("vm-kernel-parameters"))
 	}
 
 	if context.IsSet("vm-kernel-initrd") {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1643,7 +1643,7 @@ func (g *Generator) SetVMHypervisorPath(path string) error {
 }
 
 // SetVMHypervisorParameters sets g.Config.VM.Hypervisor.Parameters
-func (g *Generator) SetVMHypervisorParameters(parameters string) {
+func (g *Generator) SetVMHypervisorParameters(parameters []string) {
 	g.initConfigVMHypervisor()
 	g.Config.VM.Hypervisor.Parameters = parameters
 }
@@ -1659,7 +1659,7 @@ func (g *Generator) SetVMKernelPath(path string) error {
 }
 
 // SetVMKernelParameters sets g.Config.VM.Kernel.Parameters
-func (g *Generator) SetVMKernelParameters(parameters string) {
+func (g *Generator) SetVMKernelParameters(parameters []string) {
 	g.initConfigVMKernel()
 	g.Config.VM.Kernel.Parameters = parameters
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -160,8 +160,8 @@ type Linux struct {
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 	// MountLabel specifies the selinux context for the mounts in the container.
 	MountLabel string `json:"mountLabel,omitempty"`
-	// IntelRdt contains Intel Resource Director Technology (RDT) information
-	// for handling resource constraints (e.g., L3 cache) for the container
+	// IntelRdt contains Intel Resource Director Technology (RDT) information for
+	// handling resource constraints (e.g., L3 cache, memory bandwidth) for the container
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 }
 
@@ -528,7 +528,7 @@ type VMHypervisor struct {
 	// Path is the host path to the hypervisor used to manage the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the hypervisor.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 }
 
 // VMKernel contains information about the kernel to use for a virtual machine.
@@ -536,7 +536,7 @@ type VMKernel struct {
 	// Path is the host path to the kernel used to boot the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the kernel.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 	// InitRD is the host path to an initial ramdisk to be used by the kernel.
 	InitRD string `json:"initrd,omitempty"`
 }
@@ -623,10 +623,18 @@ type LinuxSyscall struct {
 	Args   []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
-// LinuxIntelRdt has container runtime resource constraints
-// for Intel RDT/CAT which introduced in Linux 4.10 kernel
+// LinuxIntelRdt has container runtime resource constraints for Intel RDT
+// CAT and MBA features which introduced in Linux 4.10 and 4.12 kernel
 type LinuxIntelRdt struct {
+	// The identity for RDT Class of Service
+	ClosID string `json:"closID,omitempty"`
 	// The schema for L3 cache id and capacity bitmask (CBM)
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
+
+	// The schema of memory bandwidth per L3 cache id
+	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
+	MemBwSchema string `json:"memBwSchema,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 1
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
with https://github.com/opencontainers/runtime-spec/commit/fc51617f1e5f25bb6f5db571fb0ebf5de80d17e9

the runtime tools need to change as well to update the type. Do the
simplest thing and simply allow multiple instances of the same argument to
populate the array.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>