### PR TITLE
generate: Increase the required value of windows.layerFolders

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -60,6 +60,10 @@ func New(os string) (generator Generator, err error) {
 			},
 		}
 		config.Windows = &rspec.Windows{
+			LayerFolders: []string{
+				"C:\\Layers\\layer1",
+				"C:\\Layers\\layer2",
+			},
 			IgnoreFlushesDuringBoot: true,
 			Network: &rspec.WindowsNetwork{
 				AllowUnqualifiedDNSQuery: true,


### PR DESCRIPTION
Add the required values to the layerFolders field under Windows. Modify the following error:

```
➜  runtime-tools git:(fix-generate-os-windows) ✗ oci-runtime-tool generate --os windows --output config.json
➜  runtime-tools git:(fix-generate-os-windows) ✗ oci-runtime-tool validate .
2 errors occurred:

* windows.layerFolders: Invalid type. Expected: array, given: null
* 'Windows.LayerFolders' should not be empty
➜  runtime-tools git:(fix-generate-os-windows) ✗
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>