### PR TITLE
generate: add oci-version option

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -91,6 +91,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "mounts-add", Usage: "configures additional mounts inside container"},
 	cli.StringSliceFlag{Name: "mounts-remove", Usage: "remove destination mountpoints from inside container"},
 	cli.BoolFlag{Name: "mounts-remove-all", Usage: "remove all mounts inside container"},
+	cli.StringFlag{Name: "oci-version", Usage: "specify the version of the Open Container Initiative runtime specification"},
 	cli.StringFlag{Name: "os", Value: runtime.GOOS, Usage: "operating system the container is created for"},
 	cli.StringFlag{Name: "output", Usage: "output file (defaults to stdout)"},
 	cli.BoolFlag{Name: "privileged", Usage: "enable privileged container settings"},
@@ -201,6 +202,10 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 
 	if context.IsSet("hostname") {
 		g.SetHostname(context.String("hostname"))
+	}
+
+	if context.IsSet("oci-version") {
+		g.SetOCIVersion(context.String("oci-version"))
 	}
 
 	if context.IsSet("label") {

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -369,6 +369,7 @@ _oci-runtime-tool_generate() {
 		--linux-uidmappings
 		--mounts-add
 		--mounts-remove
+		--oci-version
 		--os
 		--output
 		--process-cap-add

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -368,6 +368,12 @@ func (g *Generator) SetHostname(s string) {
 	g.Config.Hostname = s
 }
 
+// SetOCIVersion sets g.Config.Version.
+func (g *Generator) SetOCIVersion(s string) {
+	g.initConfig()
+	g.Config.Version = s
+}
+
 // ClearAnnotations clears g.Config.Annotations.
 func (g *Generator) ClearAnnotations() {
 	if g.Config == nil {

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -356,6 +356,9 @@ read the configuration from `config.json`.
   Remove all mounts inside the container. The default is *false*.
   When specified with --mount-add, this option will be parsed first.
 
+**--oci-version**=""
+  Set the version of the Open Container Initiative runtime specification.
+
 **--os**=OS
   Operating system used within the container.
 


### PR DESCRIPTION
Add oci-version option to generate to set the version of the Open Container Initiative runtime specification.

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>