### PR TITLE
Windows: Typos and incorrect defaults

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -140,6 +140,7 @@ var generateFlags = []cli.Flag{
 	cli.BoolFlag{Name: "windows-ignore-flushes-during-boot", Usage: "ignore flushes during boot"},
 	cli.StringSliceFlag{Name: "windows-layer-folders", Usage: "specifies a list of layer folders the container image relies on"},
 	cli.StringFlag{Name: "windows-network", Usage: "specifies network for container"},
+	cli.BoolFlag{Name: "windows-network-allowunqualifieddnsquery", Usage: "specifies networking unqualified DNS query is allowed"},
 	cli.StringFlag{Name: "windows-network-networkNamespace", Usage: "specifies network namespace for container"},
 	cli.StringFlag{Name: "windows-resources-cpu", Usage: "specifies CPU for container"},
 	cli.Uint64Flag{Name: "windows-resources-memory-limit", Usage: "specifies limit of memory"},
@@ -935,7 +936,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	}
 
 	if context.IsSet("windows-ignore-flushes-during-boot") {
-		g.SetWinodwsIgnoreFlushesDuringBoot(context.Bool("windows-ignore-flushes-during-boot"))
+		g.SetWindowsIgnoreFlushesDuringBoot(context.Bool("windows-ignore-flushes-during-boot"))
 	}
 
 	if context.IsSet("windows-layer-folders") {
@@ -967,6 +968,10 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		g.SetWindowsNetwork(tmpNetwork)
 	}
 
+	if context.IsSet("windows-network-allowunqualifieddnsquery") {
+		g.SetWindowsNetworkAllowUnqualifiedDNSQuery(context.Bool("windows-network-allowunqualifieddnsquery"))
+	}
+
 	if context.IsSet("windows-network-networkNamespace") {
 		g.SetWindowsNetworkNamespace(context.String("windows-network-networkNamespace"))
 	}
@@ -995,7 +1000,7 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 	}
 
 	if context.IsSet("windows-servicing") {
-		g.SetWinodwsServicing(context.Bool("windows-servicing"))
+		g.SetWindowsServicing(context.Bool("windows-servicing"))
 	}
 
 	err := addSeccomp(context, g)

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -435,6 +435,7 @@ _oci-runtime-tool_generate() {
 		--process-terminal
 		--rootfs-readonly
 		--windows-ignore-flushes-during-boot
+		--windows-network-allowunqualifieddnsquery
 		--windows-servicing
 	"
 

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -54,17 +54,8 @@ func New(os string) (generator Generator, err error) {
 				"cmd",
 			},
 			Cwd: `C:\`,
-			ConsoleSize: &rspec.Box{
-				Width:  80,
-				Height: 20,
-			},
 		}
-		config.Windows = &rspec.Windows{
-			IgnoreFlushesDuringBoot: true,
-			Network: &rspec.WindowsNetwork{
-				AllowUnqualifiedDNSQuery: true,
-			},
-		}
+		config.Windows = &rspec.Windows{}
 	} else {
 		config.Root = &rspec.Root{
 			Path:     "rootfs",
@@ -1706,8 +1697,8 @@ func (g *Generator) SetWindowsHypervUntilityVMPath(path string) {
 	g.Config.Windows.HyperV.UtilityVMPath = path
 }
 
-// SetWinodwsIgnoreFlushesDuringBoot sets g.Config.Winodws.IgnoreFlushesDuringBoot.
-func (g *Generator) SetWinodwsIgnoreFlushesDuringBoot(ignore bool) {
+// SetWindowsIgnoreFlushesDuringBoot sets g.Config.Windows.IgnoreFlushesDuringBoot.
+func (g *Generator) SetWindowsIgnoreFlushesDuringBoot(ignore bool) {
 	g.initConfigWindows()
 	g.Config.Windows.IgnoreFlushesDuringBoot = ignore
 }
@@ -1745,6 +1736,12 @@ func (g *Generator) SetWindowsNetwork(network rspec.WindowsNetwork) {
 	g.Config.Windows.Network = &network
 }
 
+// SetWindowsNetworkAllowUnqualifiedDNSQuery sets g.Config.Windows.Network.AllowUnqualifiedDNSQuery
+func (g *Generator) SetWindowsNetworkAllowUnqualifiedDNSQuery(setting bool) {
+	g.initConfigWindowsNetwork()
+	g.Config.Windows.Network.AllowUnqualifiedDNSQuery = setting
+}
+
 // SetWindowsNetworkNamespace sets g.Config.Windows.Network.NetworkNamespace
 func (g *Generator) SetWindowsNetworkNamespace(path string) {
 	g.initConfigWindowsNetwork()
@@ -1769,8 +1766,8 @@ func (g *Generator) SetWindowsResourcesStorage(storage rspec.WindowsStorageResou
 	g.Config.Windows.Resources.Storage = &storage
 }
 
-// SetWinodwsServicing sets g.Config.Winodws.Servicing.
-func (g *Generator) SetWinodwsServicing(servicing bool) {
+// SetWindowsServicing sets g.Config.Windows.Servicing.
+func (g *Generator) SetWindowsServicing(servicing bool) {
 	g.initConfigWindows()
 	g.Config.Windows.Servicing = servicing
 }

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -552,6 +552,9 @@ read the configuration from `config.json`.
   Specifies network for container.
   e.g. --windows-network='{"endpointList": ["7a010682-17e0-4455-a838-02e5d9655fe6"],"allowUnqualifiedDNSQuery": true,"DNSSearchList": ["a.com"],"networkSharedContainerName": "containerName", "networkNamespace" : "15010682-17e0-4455-a838-02e5d9655f00"}'
 
+**--windows-network-allowunqualifieddnsquery**=true|false
+  Whether to allow unqualified DNS queries
+
 **--windows-network-networkNamespace**=""
   Specified the network namespace for the container
   e.g. --windows-network-networkNamespace '15010682-17e0-4455-a838-02e5d9655f00'


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

There were a few typos `Winodws` which should be `Windows` (obviously).

It also corrects the defaults for Windows. Neither `IgnoreFlushesDuringBoot` nor networkings `AllowUnqualifiedDNSQuery` should be defaulted to true. Also, the assumption that there is a console is incorrect. These should all be set explicitly, if required, by callers.

@jterry75 FYI