### PR TITLE
adding security and CoC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 oci-runtime-tool is a collection of tools for working with the [OCI runtime specification][runtime-spec].
 To build from source code, runtime-tools requires Go 1.10.x or above.
 
+## Table of Contents
+
+Additional documentation about how this group operates:
+
+- [Code of Conduct][code-of-conduct]
+- [security][security]
+
+
 ## Generating an OCI runtime spec configuration files
 
 [`oci-runtime-tool generate`][generate.1] generates [configuration JSON][config.json] for an [OCI bundle][bundle].
@@ -112,6 +120,8 @@ Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.03 cusr  0.03 csys
 Result: PASS
 ```
 
+[security]: https://github.com/opencontainers/org/blob/master/security
+[code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md
 [bundle]: https://github.com/opencontainers/runtime-spec/blob/master/bundle.md
 [config.json]: https://github.com/opencontainers/runtime-spec/blob/master/config.md
 [debian-node-tap]: https://packages.debian.org/stretch/node-tap


### PR DESCRIPTION
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

This will add a link to the code of conduct and security pages to address https://github.com/opencontainers/org/issues/3