### PR TITLE
validation-tests: fix several tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ validation-executables: $(VALIDATION_TESTS)
 $(VALIDATION_TESTS): %.t: %.go
 	go build -tags "$(BUILDTAGS)" ${TESTFLAGS} -o $@ $<
 
-.PHONY: test .gofmt .govet .golint
+print-validation-tests:
+	@echo $(VALIDATION_TESTS)
+
+.PHONY: test .gofmt .govet .golint print-validation-tests
 
 PACKAGES = $(shell go list ./... | grep -v vendor)
 test: .gofmt .govet .golint .gotest

--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -1204,6 +1204,16 @@ func (c *complianceTester) validateMountLabel(spec *rspec.Spec) error {
 	}
 
 	for _, mount := range spec.Mounts {
+		isBind := false
+		for _, opt := range mount.Options {
+			if opt == "bind" || opt == "rbind" {
+				isBind = true
+				break
+			}
+		}
+		if !isBind {
+			continue
+		}
 		fileLabel, err := label.FileLabel(mount.Destination)
 		if err != nil {
 			return fmt.Errorf("Failed to get mountLabel of %v", mount.Destination)

--- a/validation/delete/delete.go
+++ b/validation/delete/delete.go
@@ -16,6 +16,8 @@ import (
 func main() {
 	t := tap.New()
 	t.Header(0)
+	defer t.AutoPlan()
+
 	bundleDir, err := util.PrepareBundle()
 	if err != nil {
 		util.Fatal(err)
@@ -72,7 +74,7 @@ func main() {
 
 		if c.effectCheck {
 			// waiting for the error of State, just in case the delete operation takes time
-			util.WaitingForStatus(testRuntime, util.LifecycleActionNone, time.Second*10, time.Second*1)
+			util.WaitingForStatus(testRuntime, util.LifecycleActionNone, time.Second*3, time.Second/2)
 			_, err = testRuntime.State()
 			// err == nil means the 'delete' operation does NOT take effect
 			util.SpecErrorOK(t, err == nil, specerror.NewError(specerror.DeleteNonStopHaveNoEffect, fmt.Errorf("attempting to `delete` a container that is not `stopped` MUST have no effect on the container"), rspecs.Version), err)
@@ -89,6 +91,4 @@ func main() {
 			}
 		}
 	}
-
-	t.AutoPlan()
 }

--- a/validation/kill/kill.go
+++ b/validation/kill/kill.go
@@ -70,6 +70,10 @@ func main() {
 				// KILL MUST be supported and KILL cannot be trapped
 				err = r.Kill("KILL")
 				util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second*1)
+				if err != nil {
+					//Be sure to not leave the container around
+					r.Delete()
+				}
 				return err
 			},
 		}

--- a/validation/linux_seccomp/linux_seccomp.go
+++ b/validation/linux_seccomp/linux_seccomp.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	tap "github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/generate/seccomp"
 	"github.com/opencontainers/runtime-tools/validation/util"
 )
 
 func main() {
+	t := tap.New()
+	t.Header(0)
+	defer t.AutoPlan()
 	g, err := util.GetDefaultGenerator()
 	if err != nil {
 		util.Fatal(err)
@@ -16,8 +20,10 @@ func main() {
 	}
 	g.SetDefaultSeccompAction("allow")
 	g.SetSyscallAction(syscallArgs)
-	err = util.RuntimeInsideValidate(g, nil, nil)
+	err = util.RuntimeInsideValidate(g, t, nil)
+	t.Ok(err == nil, "seccomp action is added correctly")
 	if err != nil {
-		util.Fatal(err)
+		t.Fail(err.Error())
 	}
+
 }

--- a/validation/misc_props/misc_props.go
+++ b/validation/misc_props/misc_props.go
@@ -45,9 +45,15 @@ func main() {
 		util.Fatal(err)
 	}
 	basicConfig.SetProcessArgs([]string{"true"})
-	annotationConfig := basicConfig
+	annotationConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	annotationConfig.AddAnnotation(fmt.Sprintf("org.%s", containerID), "")
-	invalidConfig := basicConfig
+	invalidConfig, err := util.GetDefaultGenerator()
+	if err != nil {
+		util.Fatal(err)
+	}
 	invalidConfig.SetVersion("invalid")
 
 	cases := []struct {

--- a/validation/process_capabilities_fail/process_capabilities_fail.go
+++ b/validation/process_capabilities_fail/process_capabilities_fail.go
@@ -20,7 +20,7 @@ func main() {
 	if err != nil {
 		util.Fatal(err)
 	}
-	g.AddProcessCapabilityBounding("CAP_TEST")
+	g.Config.Process.Capabilities.Bounding = append(g.Config.Process.Capabilities.Bounding, "CAP_TEST")
 	err = util.RuntimeInsideValidate(g, nil, nil)
 	if err == nil {
 		util.Fatal(specerror.NewError(specerror.LinuxProcCapError, fmt.Errorf("Any value which cannot be mapped to a relevant kernel interface MUST cause an error"), rspecs.Version))

--- a/validation/state/state.go
+++ b/validation/state/state.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
@@ -44,6 +45,8 @@ func main() {
 			},
 			PostCreate: func(r *util.Runtime) error {
 				_, err = r.State()
+				r.Kill("KILL")
+				util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second)
 				return err
 			},
 		}

--- a/validation/util/container.go
+++ b/validation/util/container.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
@@ -197,6 +198,9 @@ func (r *Runtime) Delete() (err error) {
 // forceRemoveBundle is true, after the deletion attempt regardless of
 // whether it was successful or not.
 func (r *Runtime) Clean(removeBundle bool, forceRemoveBundle bool) error {
+	r.Kill("KILL")
+	WaitingForStatus(*r, LifecycleStatusStopped, time.Second*10, time.Second/10)
+
 	err := r.Delete()
 
 	if removeBundle && (err == nil || forceRemoveBundle) {

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -350,7 +350,8 @@ func RuntimeLifecycleValidate(config LifecycleConfig) error {
 				if _, err := r.State(); err != nil {
 					return
 				}
-				err := WaitingForStatus(r, LifecycleStatusCreated|LifecycleStatusStopped, time.Second*10, time.Second*1)
+				r.Kill("KILL")
+				err := WaitingForStatus(r, LifecycleStatusStopped, time.Second*10, time.Second*1)
 				if err == nil {
 					r.Delete()
 				} else {


### PR DESCRIPTION
this PR includes several minor fixes to the validation tests.  I've found these issues while preparing `crun` to be fully OCI compliant: https://github.com/giuseppe/crun/pull/16

More details are included in the commit message for each patch.

I've added a patch for the Makefile to print what validation-tests are used.  I want to use it on Travis to easily read the list of the tests and disabling some of them, namely some cgroup tests that require a special configuration (I could just repeat the same find query, but I'd prefer to keep this logic in the runtime-tools Makefile)