### PR TITLE
validate: Fix CheckRoot panic error

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -171,19 +171,23 @@ func (v *Validator) CheckJSONSchema() (errs error) {
 func (v *Validator) CheckRoot() (errs error) {
 	logrus.Debugf("check root")
 
-	if v.platform == "windows" && v.spec.Windows != nil {
-		if v.spec.Windows.HyperV != nil {
-			if v.spec.Root != nil {
+	if v.platform == "windows" {
+		if v.spec.Windows != nil {
+			if v.spec.Windows.HyperV != nil {
+				if v.spec.Root != nil {
+					errs = multierror.Append(errs,
+						specerror.NewError(specerror.RootOnHyperVNotSet, fmt.Errorf("for Hyper-V containers, Root must not be set"), rspec.Version))
+				}
+				return
+			} else if v.spec.Root == nil {
 				errs = multierror.Append(errs,
-					specerror.NewError(specerror.RootOnHyperVNotSet, fmt.Errorf("for Hyper-V containers, Root must not be set"), rspec.Version))
+					specerror.NewError(specerror.RootOnWindowsRequired, fmt.Errorf("on Windows, for Windows Server Containers, this field is REQUIRED"), rspec.Version))
+				return
 			}
-			return
 		} else if v.spec.Root == nil {
-			errs = multierror.Append(errs,
-				specerror.NewError(specerror.RootOnWindowsRequired, fmt.Errorf("on Windows, for Windows Server Containers, this field is REQUIRED"), rspec.Version))
 			return
 		}
-	} else if v.platform != "windows" && v.spec.Root == nil {
+	} else if v.spec.Root == nil {
 		errs = multierror.Append(errs,
 			specerror.NewError(specerror.RootOnNonWindowsRequired, fmt.Errorf("on all other platforms, this field is REQUIRED"), rspec.Version))
 		return


### PR DESCRIPTION
Fix the following panic error:

```
➜  runtime-tools git:(windows-panic) ✗ cat config.json
{
        "ociVersion": "1.0.1"
}

➜  runtime-tools git:(add-validate-tests) ✗ ./oci-runtime-tool validate --platform windows .
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x70aa6e]

goroutine 1 [running]:
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckRoot(0xc00024f8c8, 0xc00034cac0, 0xc00024f730)
        /data/data/workspace/Go/src/github.com/opencontainers/runtime-tools/validate/validate.go:215 +0x22e
github.com/opencontainers/runtime-tools/validate.(*Validator).CheckAll(0xc00024f8c8, 0x1, 0x0)
        /data/data/workspace/Go/src/github.com/opencontainers/runtime-tools/validate/validate.go:111 +0x119
main.glob..func2(0xc0000b48c0, 0x0, 0xc0000b48c0)
        /data/data/workspace/Go/src/github.com/opencontainers/runtime-tools/cmd/oci-runtime-tool/validate.go:39 +0x1ed
github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.HandleAction(0x7a3340, 0x83bce0, 0xc0000b48c0, 0xc00008e600, 0x0)
        /data/data/workspace/Go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/app.go:485 +0xc8
github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli.Command.Run(0x820a2d, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x826c32, 0x16, 0x0, ...)
        /data/data/workspace/Go/src/github.com/opencontainers/runtime-tools/vendor/github.com/urfave/cli/command.go:193 +0x98e
```

Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>