### PR TITLE
seccomp: add CloneNewCgroup to check sysCloneFlagsIndex

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -513,7 +513,7 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				Args: []rspec.LinuxSeccompArg{
 					{
 						Index:    sysCloneFlagsIndex,
-						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet,
+						Value:    CloneNewNS | CloneNewUTS | CloneNewIPC | CloneNewUser | CloneNewPID | CloneNewNet | CloneNewCgroup,
 						ValueTwo: 0,
 						Op:       rspec.OpMaskedEqual,
 					},

--- a/generate/seccomp/seccomp_default_linux.go
+++ b/generate/seccomp/seccomp_default_linux.go
@@ -3,14 +3,15 @@
 
 package seccomp
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 // System values passed through on linux
 const (
-	CloneNewIPC  = syscall.CLONE_NEWIPC
-	CloneNewNet  = syscall.CLONE_NEWNET
-	CloneNewNS   = syscall.CLONE_NEWNS
-	CloneNewPID  = syscall.CLONE_NEWPID
-	CloneNewUser = syscall.CLONE_NEWUSER
-	CloneNewUTS  = syscall.CLONE_NEWUTS
+	CloneNewIPC    = unix.CLONE_NEWIPC
+	CloneNewNet    = unix.CLONE_NEWNET
+	CloneNewNS     = unix.CLONE_NEWNS
+	CloneNewPID    = unix.CLONE_NEWPID
+	CloneNewUser   = unix.CLONE_NEWUSER
+	CloneNewUTS    = unix.CLONE_NEWUTS
+	CloneNewCgroup = unix.CLONE_NEWCGROUP
 )


### PR DESCRIPTION
All clone flags should be denied as default profile.
Also x/sys should be used instead of syscall.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>