### PR TITLE
Add missing clone rule for s390x. Fixes #699

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -566,6 +566,20 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 			},
 		}...)
 		/* Flags parameter of the clone syscall is the 2nd on s390 */
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
+			{
+				Names:  []string{"clone"},
+				Action: rspec.ActAllow,
+				Args: []rspec.LinuxSeccompArg{
+					{
+						Index:    1,
+						Value:    2080505856,
+						ValueTwo: 0,
+						Op:       rspec.OpMaskedEqual,
+					},
+				},
+			},
+		}...)
 	}
 
 	return &rspec.LinuxSeccomp{


### PR DESCRIPTION
Fixes https://github.com/opencontainers/runtime-tools/issues/699

This PR adds the missing [clone masked_eq seccomp](https://github.com/cri-o/cri-o/blob/master/vendor/github.com/seccomp/containers-golang/seccomp.json#L607-L632) rule which causes clone syscalls to fail on s390x.

I have only tested this patch directly in cri-o so far.  Please consider this PR a work in progress while I become familiar with this project and its processes such as writing and running unit tests, etc.

Additionally, since this patch only affects s390x, please let me know if there is anything extra I should do to test the architecture-specific functionality.

Thanks,
DB