### PR TITLE
AddDevice(): better diagnostic when creating dup

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1496,7 +1496,7 @@ func (g *Generator) AddDevice(device rspec.LinuxDevice) {
 			return
 		}
 		if dev.Type == device.Type && dev.Major == device.Major && dev.Minor == device.Minor {
-			fmt.Fprintln(os.Stderr, "WARNING: The same type, major and minor should not be used for multiple devices.")
+			fmt.Fprintf(os.Stderr, "WARNING: Creating device %q with same type, major and minor as existing %q.\n", device.Path, dev.Path)
 		}
 	}
 


### PR DESCRIPTION
The existing diagnostic[1] appeared in a CI job with no
possible hope of figuring out the source of the problem.
This PR amends the diagnostic to include the name of
the requested newly-created device as well as the
existing "duplicate".

 [1] WARNING: The same type, major and minor should not be used for multiple devices.

(I am not convinced that this condition merits a warning
but will leave that discussion to better minds than mine).

Signed-off-by: Ed Santiago <santiago@redhat.com>