### PR TITLE
generate: fix type for Umask

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/opencontainers/runtime-tools",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v77",
+	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
 	],
@@ -35,8 +35,8 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runtime-spec/specs-go",
-			"Comment": "v1.0.2",
-		        "Rev": "c4ee7d12c742ffe806cd9350b6af3b4b19faed6f"
+			"Comment": "v1.0.2-41-g7413a7f",
+			"Rev": "7413a7f753e1bd9a6a9c6dc7f96f55888cbbd476"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -447,7 +447,8 @@ func (g *Generator) SetProcessUsername(username string) {
 // SetProcessUmask sets g.Config.Process.User.Umask.
 func (g *Generator) SetProcessUmask(umask uint32) {
 	g.initConfigProcess()
-	g.Config.Process.User.Umask = umask
+	u := umask
+	g.Config.Process.User.Umask = &u
 }
 
 // SetProcessGID sets g.Config.Process.User.GID.

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -144,7 +144,7 @@ func JSONSchemaURL(version string) (url string, err error) {
 func (v *Validator) CheckJSONSchema() (errs error) {
 	logrus.Debugf("check JSON schema")
 
-	url, err := JSONSchemaURL(v.spec.Version)
+	url, err := JSONSchemaURL(strings.TrimSuffix(v.spec.Version, "-dev"))
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		return errs

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -43,7 +43,7 @@ func TestJSONSchema(t *testing.T) {
 	}{
 		{
 			config: &rspec.Spec{},
-			error:  "1 error occurred:\n\t* Version string empty\nRefer to: https://github.com/opencontainers/runtime-spec/blob/v1.0.2/config.md#specification-version\n\n",
+			error:  fmt.Sprintf("1 error occurred:\n\t* Version string empty\nRefer to: https://github.com/opencontainers/runtime-spec/blob/v%s/config.md#specification-version\n\n", rspec.Version),
 		},
 		{
 			config: &rspec.Spec{

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -52,11 +52,11 @@ const (
 	LifecycleStatusStopped
 )
 
-var lifecycleStatusMap = map[string]LifecycleStatus{
-	"creating": LifecycleStatusCreating,
-	"created":  LifecycleStatusCreated,
-	"running":  LifecycleStatusRunning,
-	"stopped":  LifecycleStatusStopped,
+var lifecycleStatusMap = map[rspec.ContainerState]LifecycleStatus{
+	rspec.StateCreating: LifecycleStatusCreating,
+	rspec.StateCreated:  LifecycleStatusCreated,
+	rspec.StateRunning:  LifecycleStatusRunning,
+	rspec.StateStopped:  LifecycleStatusStopped,
 }
 
 // LifecycleConfig includes

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -60,7 +60,7 @@ type Process struct {
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// LinuxCapabilities specifies the whitelist of capabilities that are kept for a process.
+// LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
 // http://man7.org/linux/man-pages/man7/capabilities.7.html
 type LinuxCapabilities struct {
 	// Bounding is the set of capabilities checked by the kernel.
@@ -90,7 +90,7 @@ type User struct {
 	// GID is the group id.
 	GID uint32 `json:"gid" platform:"linux,solaris"`
 	// Umask is the umask for the init process.
-	Umask uint32 `json:"umask,omitempty" platform:"linux,solaris"`
+	Umask *uint32 `json:"umask,omitempty" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 	// Username is the user name.
@@ -354,7 +354,7 @@ type LinuxRdma struct {
 
 // LinuxResources has container runtime resource constraints
 type LinuxResources struct {
-	// Devices configures the device whitelist.
+	// Devices configures the device allowlist.
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
@@ -372,6 +372,8 @@ type LinuxResources struct {
 	// Limits are a set of key value pairs that define RDMA resource limits,
 	// where the key is device name and value is resource limits.
 	Rdma map[string]LinuxRdma `json:"rdma,omitempty"`
+	// Unified resources.
+	Unified map[string]string `json:"unified,omitempty"`
 }
 
 // LinuxDevice represents the mknod information for a Linux special device file
@@ -392,7 +394,8 @@ type LinuxDevice struct {
 	GID *uint32 `json:"gid,omitempty"`
 }
 
-// LinuxDeviceCgroup represents a device rule for the whitelist controller
+// LinuxDeviceCgroup represents a device rule for the devices specified to
+// the device controller
 type LinuxDeviceCgroup struct {
 	// Allow or deny
 	Allow bool `json:"allow"`
@@ -628,6 +631,7 @@ const (
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
 	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
 	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
+	ArchRISCV64     Arch = "SCMP_ARCH_RISCV64"
 )
 
 // LinuxSeccompAction taken upon Seccomp rule match
@@ -635,12 +639,14 @@ type LinuxSeccompAction string
 
 // Define actions for Seccomp rules
 const (
-	ActKill  LinuxSeccompAction = "SCMP_ACT_KILL"
-	ActTrap  LinuxSeccompAction = "SCMP_ACT_TRAP"
-	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
-	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
-	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
-	ActLog   LinuxSeccompAction = "SCMP_ACT_LOG"
+	ActKill        LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActKillProcess LinuxSeccompAction = "SCMP_ACT_KILL_PROCESS"
+	ActKillThread  LinuxSeccompAction = "SCMP_ACT_KILL_THREAD"
+	ActTrap        LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno       LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace       LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow       LinuxSeccompAction = "SCMP_ACT_ALLOW"
+	ActLog         LinuxSeccompAction = "SCMP_ACT_LOG"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp
@@ -667,9 +673,10 @@ type LinuxSeccompArg struct {
 
 // LinuxSyscall is used to match a syscall in Seccomp
 type LinuxSyscall struct {
-	Names  []string           `json:"names"`
-	Action LinuxSeccompAction `json:"action"`
-	Args   []LinuxSeccompArg  `json:"args,omitempty"`
+	Names    []string           `json:"names"`
+	Action   LinuxSeccompAction `json:"action"`
+	ErrnoRet *uint              `json:"errnoRet,omitempty"`
+	Args     []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
 // LinuxIntelRdt has container runtime resource constraints for Intel RDT

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -1,5 +1,23 @@
 package specs
 
+// ContainerState represents the state of a container.
+type ContainerState string
+
+const (
+	// StateCreating indicates that the container is being created
+	StateCreating ContainerState  = "creating"
+
+	// StateCreated indicates that the runtime has finished the create operation
+	StateCreated ContainerState  = "created"
+
+	// StateRunning indicates that the container process has executed the
+	// user-specified program but has not exited
+	StateRunning ContainerState  = "running"
+
+	// StateStopped indicates that the container process has exited
+	StateStopped ContainerState  = "stopped"
+)
+
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.
@@ -7,7 +25,7 @@ type State struct {
 	// ID is the container ID
 	ID string `json:"id"`
 	// Status is the runtime status of the container.
-	Status string `json:"status"`
+	Status ContainerState `json:"status"`
 	// Pid is the process ID for the container process.
 	Pid int `json:"pid,omitempty"`
 	// Bundle is the path to the container's bundle directory.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
umask is a pointer to an uint32.

The error was first present in the runtime-specs Go bindings and it
was fixed with:

https://github.com/opencontainers/runtime-spec/pull/1058

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>