### PR TITLE
Fix build of hugetlb tests on 32-bit platforms

### DIFF
--- a/validation/linux_cgroups_hugetlb/linux_cgroups_hugetlb.go
+++ b/validation/linux_cgroups_hugetlb/linux_cgroups_hugetlb.go
@@ -24,7 +24,7 @@ func testHugetlbCgroups() error {
 	// When setting the limit just for checking if writing works, the amount of memory
 	// requested does not matter, as all insigned integers will be accepted.
 	// Use 2GiB as an example
-	const limit = 2 * (1 << 30)
+	var limit uint64 = 2 * (1 << 30)
 
 	for _, pageSize := range pageSizes {
 		g, err := util.GetDefaultGenerator()

--- a/validation/linux_cgroups_relative_hugetlb/linux_cgroups_relative_hugetlb.go
+++ b/validation/linux_cgroups_relative_hugetlb/linux_cgroups_relative_hugetlb.go
@@ -21,7 +21,7 @@ func main() {
 	// When setting the limit just for checking if writing works, the amount of memory
 	// requested does not matter, as all insigned integers will be accepted.
 	// Use 2GiB as an example
-	const limit = 2 * (1 << 30)
+	var limit uint64 = 2 * (1 << 30)
 
 	for _, pageSize := range pageSizes {
 		g, err := util.GetDefaultGenerator()


### PR DESCRIPTION
Use explicit 64-bit types to avoid fall-back on incompatible 32-bit
types on 32-bit platforms.

Fixes: #711
Signed-off-by: Daniel Golle <daniel@makrotopia.org>