### PR TITLE
validation: read pid in PostCreate

### DIFF
--- a/validation/hooks_stdin/hooks_stdin.go
+++ b/validation/hooks_stdin/hooks_stdin.go
@@ -127,12 +127,15 @@ func main() {
 			r.SetID(containerID)
 			return nil
 		},
-		PreDelete: func(r *util.Runtime) error {
+		PostCreate: func(r *util.Runtime) error {
 			state, err := r.State()
 			if err != nil {
 				return err
 			}
 			containerPid = state.Pid
+			return nil
+		},
+		PreDelete: func(r *util.Runtime) error {
 			util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second)
 			return nil
 		},


### PR DESCRIPTION
do not read the container pid in PreDelete as it might be already
terminated ("true" is a short lived process).

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>