### PR TITLE
generate: add --linux-intelRdt-closid option

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -53,6 +53,7 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "linux-gidmappings", Usage: "add GIDMappings e.g HostID:ContainerID:Size"},
 	cli.StringSliceFlag{Name: "linux-hugepage-limits-add", Usage: "add hugepage resource limits"},
 	cli.StringSliceFlag{Name: "linux-hugepage-limits-drop", Usage: "drop hugepage resource limits"},
+	cli.StringFlag{Name: "linux-intelRdt-closid", Usage: "RDT Class of Service, i.e. group under the resctrl pseudo-filesystem which to associate the container with"},
 	cli.StringFlag{Name: "linux-intelRdt-l3CacheSchema", Usage: "specifies the schema for L3 cache id and capacity bitmask"},
 	cli.StringSliceFlag{Name: "linux-masked-paths", Usage: "specifies paths can not be read inside container"},
 	cli.Uint64Flag{Name: "linux-mem-kernel-limit", Usage: "kernel memory limit (in bytes)"},
@@ -744,6 +745,10 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 		for _, v := range pageList {
 			g.DropLinuxResourcesHugepageLimit(v)
 		}
+	}
+
+	if context.IsSet("linux-intelRdt-closid") {
+		g.SetLinuxIntelRdtClosID(context.String("linux-intelRdt-closid"))
 	}
 
 	if context.IsSet("linux-intelRdt-l3CacheSchema") {

--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -335,6 +335,7 @@ _oci-runtime-tool_generate() {
 		--linux-gidmappings
 		--linux-hugepage-limits-add
 		--linux-hugepage-limits-drop
+		--linux-intelRdt-closid
 		--linux-intelRdt-l3CacheSchema
 		--linux-masked-paths
 		--linux-mem-kernel-limit

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -604,6 +604,12 @@ func (g *Generator) SetLinuxCgroupsPath(path string) {
 	g.Config.Linux.CgroupsPath = path
 }
 
+// SetLinuxIntelRdtClosID sets g.Config.Linux.IntelRdt.ClosID
+func (g *Generator) SetLinuxIntelRdtClosID(clos string) {
+	g.initConfigLinuxIntelRdt()
+	g.Config.Linux.IntelRdt.ClosID = clos
+}
+
 // SetLinuxIntelRdtL3CacheSchema sets g.Config.Linux.IntelRdt.L3CacheSchema
 func (g *Generator) SetLinuxIntelRdtL3CacheSchema(schema string) {
 	g.initConfigLinuxIntelRdt()

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -193,6 +193,10 @@ read the configuration from `config.json`.
   Drop hugepage rsource limits. Just need to specify PAGESIZE. e.g. --linux-hugepage-limits-drop=4MB
   This option can be specified multiple times.
 
+**--linux-intelRdt-closid**=""
+  RDT Class of Service, i.e. group under the resctrl pseudo-filesystem, which
+  to associate the container with.
+
 **--linux-intelRdt-l3CacheSchema**=""
   Specifies the schema for L3 cache id and capacity bitmask.
 


### PR DESCRIPTION
Makes it possible to specify the closID parameter of intelRdt in linux
runtime spec.

Signed-off-by: Markus Lehtonen <markus.lehtonen@intel.com>