### PR TITLE
spec generator support setting unified

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -123,6 +123,13 @@ func (g *Generator) initConfigLinuxResourcesPids() {
 	}
 }
 
+func (g *Generator) initConfigLinuxResourcesUnified() {
+	g.initConfigLinuxResources()
+	if g.Config.Linux.Resources.Unified == nil {
+		g.Config.Linux.Resources.Unified = map[string]string{}
+	}
+}
+
 func (g *Generator) initConfigSolaris() {
 	g.initConfig()
 	if g.Config.Solaris == nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -857,6 +857,28 @@ func (g *Generator) DropLinuxResourcesHugepageLimit(pageSize string) {
 	}
 }
 
+// AddLinuxResourcesUnified sets the g.Config.Linux.Resources.Unified
+func (g *Generator) SetLinuxResourcesUnified(unified map[string]string) {
+	g.initConfigLinuxResourcesUnified()
+	for k, v := range unified {
+		g.Config.Linux.Resources.Unified[k] = v
+	}
+}
+
+// AddLinuxResourcesUnified adds or updates the key-value pair from g.Config.Linux.Resources.Unified
+func (g *Generator) AddLinuxResourcesUnified(key, val string) {
+	g.initConfigLinuxResourcesUnified()
+	g.Config.Linux.Resources.Unified[key] = val
+}
+
+// DropLinuxResourcesUnified drops a key-value pair from g.Config.Linux.Resources.Unified
+func (g *Generator) DropLinuxResourcesUnified(key string) {
+	if g.Config == nil || g.Config.Linux == nil || g.Config.Linux.Resources == nil || g.Config.Linux.Resources.Unified == nil {
+		return
+	}
+	delete(g.Config.Linux.Resources.Unified, key)
+}
+
 // SetLinuxResourcesMemoryLimit sets g.Config.Linux.Resources.Memory.Limit.
 func (g *Generator) SetLinuxResourcesMemoryLimit(limit int64) {
 	g.initConfigLinuxResourcesMemory()


### PR DESCRIPTION
From
- [#1040](https://github.com/opencontainers/runtime-spec/pull/1040).
- [#KEP-2570: Support memory qos with cgroups v2](https://github.com/kubernetes/enhancements/pull/2571)
- [#102578](https://github.com/kubernetes/kubernetes/pull/102578).

When use cgroup v2, containerd and cri-o should set unified. 

Signed-off-by: Zhiyu Li <payall4u@qq.com>