### PR TITLE
Revert "validation: fix/rename ReadStandardStreams"

### DIFF
--- a/validation/util/container.go
+++ b/validation/util/container.go
@@ -112,9 +112,7 @@ func (r *Runtime) Create() (err error) {
 func (r *Runtime) ReadStandardStreams() (stdout []byte, stderr []byte, err error) {
 	_, err = r.stdout.Seek(0, io.SeekStart)
 	stdout, err2 := ioutil.ReadAll(r.stdout)
-	if err == nil && err2 != nil {
-		err = err2
-	}
+
 	_, err = r.stderr.Seek(0, io.SeekStart)
 	stderr, err2 = ioutil.ReadAll(r.stderr)
 	if err == nil && err2 != nil {

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -228,7 +228,16 @@ func RuntimeInsideValidate(g *generate.Generator, t *tap.T, f PreFunc) (err erro
 		return err
 	}
 
-	stdout, stderr := r.StandardStreams()
+	stdout, stderr, err := r.ReadStandardStreams()
+	if err != nil {
+		if len(stderr) == 0 {
+			stderr = stdout
+		}
+		os.Stderr.WriteString("failed to read standard streams\n")
+		os.Stderr.Write(stderr)
+		return err
+	}
+
 	// Write stdout in the outter TAP
 	if t != nil {
 		diagnostic := map[string]string{


### PR DESCRIPTION
Hi Team,

I think commit https://github.com/opencontainers/runtime-tools/commit/0ab61aed92a67a6e72b68fc0dd6322c95e4bb05b  introduces an issue with latest build of `runtime-tools`.
Please find more details here https://github.com/containers/crun/pull/760

Could we please revert this commit.

Thanks