### PR TITLE
cmd/runtimetest: fix NewPid deprecation warning

### DIFF
--- a/cmd/runtimetest/main.go
+++ b/cmd/runtimetest/main.go
@@ -272,8 +272,11 @@ func (c *complianceTester) validateCapabilities(spec *rspec.Spec) error {
 		last = capability.CAP_BLOCK_SUSPEND
 	}
 
-	processCaps, err := capability.NewPid(0)
+	processCaps, err := capability.NewPid2(0)
 	if err != nil {
+		return err
+	}
+	if err := processCaps.Load(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is supposed to be in commit 8e1a3b587864ef but apparently I lost a
hunk during rebase 😕 

Fixes: #737