### PR TITLE
Fix hanging on runc create.

### DIFF
--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -228,7 +228,16 @@ func RuntimeInsideValidate(g *generate.Generator, t *tap.T, f PreFunc) (err erro
 		return err
 	}
 
-	stdout, stderr := r.StandardStreams()
+	stdout, stderr, err := r.ReadStandardStreams()
+	if err != nil {
+		if len(stderr) == 0 {
+			stderr = stdout
+		}
+		os.Stderr.WriteString("failed to read standard streams\n")
+		os.Stderr.Write(stderr)
+		return err
+	}
+
 	// Write stdout in the outter TAP
 	if t != nil {
 		diagnostic := map[string]string{


### PR DESCRIPTION
This reverts commit 0ab61aed92a67a6e72b68fc0dd6322c95e4bb05b, and also
* changes `ReadStandardStreams` to use `ioutils.ReadFile`;
* changes the uuid module used by the code (see commit abcb94dc55c6c4a).

Using `bytes.Buffer` instead of plain `os.File` results in go runtime
creating two sets of pipes and spawning two threads (for stdout and
stderr) that copy the data from the pipe to the buffers.

It is not working when we execute runc create, because it spawns a child
(runc init) whose stdout and stderr are kept connected to the write ends
of the above pipes. As a result, those copying routines never finish,
and `cmd.Run()` never returns as it waits for those routines.

Therefore, let's go back to using temporary files. Note that the new
code is using `ioutil.ReadAll` instead of reusing the opened file
descriptors, which seems a bit cleaner.

Closes: #735