### PR TITLE
Followup fixes to validator

### DIFF
--- a/validation/create/create.go
+++ b/validation/create/create.go
@@ -5,12 +5,12 @@ import (
 	"os/exec"
 	"runtime"
 
+	"github.com/google/uuid"
 	"github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -33,7 +33,7 @@ func main() {
 	if err != nil {
 		util.Fatal(err)
 	}
-	defer r.Clean(true, true)
+	defer r.Clean()
 
 	err = r.SetConfig(&g)
 	if err != nil {

--- a/validation/linux_rootfs_propagation/linux_rootfs_propagation.go
+++ b/validation/linux_rootfs_propagation/linux_rootfs_propagation.go
@@ -10,9 +10,13 @@ func testLinuxRootPropagation(t *tap.T, propMode string) error {
 	if err != nil {
 		util.Fatal(err)
 	}
-	g.SetupPrivileged(true)
+	// Test case validateRootfsPropagation needs CAP_SYS_ADMIN to perform mounts.
+	g.AddProcessCapability("CAP_SYS_ADMIN")
+	// The generated seccomp profile does not enable mount/umount/umount2 syscalls.
+	g.Config.Linux.Seccomp = nil
+
 	g.SetLinuxRootPropagation(propMode)
-	g.AddAnnotation("TestName", "check root propagation")
+	g.AddAnnotation("TestName", "check root propagation: "+propMode)
 	return util.RuntimeInsideValidate(g, t, nil)
 }
 

--- a/validation/util/container.go
+++ b/validation/util/container.go
@@ -198,21 +198,16 @@ func (r *Runtime) del(force bool) (err error) {
 	return execWithStderrFallbackToStdout(cmd)
 }
 
-// Clean deletes the container.  If removeBundle is set, the bundle
-// directory is removed after the container is deleted successfully or, if
-// forceRemoveBundle is true, after the deletion attempt regardless of
-// whether it was successful or not.
-func (r *Runtime) Clean(removeBundle bool, forceRemoveBundle bool) {
+// Clean kills and removes the container and its bundle directory.
+func (r *Runtime) Clean() {
 	err := r.ForceDelete()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Clean: Delete: ", err)
 	}
 
-	if removeBundle && (err == nil || forceRemoveBundle) {
-		err := os.RemoveAll(r.bundleDir())
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Clean: ", err)
-		}
+	err = os.RemoveAll(r.bundleDir())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Clean: ", err)
 	}
 }
 

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -11,18 +11,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mndrix/tap-go"
 	"github.com/mrunalp/fileutils"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/runtime-tools/specerror"
-	"github.com/google/uuid"
 )
 
-var (
-	// RuntimeCommand is the default runtime command.
-	RuntimeCommand = "runc"
-)
+// RuntimeCommand is the default runtime command.
+var RuntimeCommand = "runc"
 
 // LifecycleAction defines the phases will be called.
 type LifecycleAction int
@@ -194,7 +192,7 @@ func RuntimeInsideValidate(g *generate.Generator, t *tap.T, f PreFunc) (err erro
 		os.RemoveAll(bundleDir)
 		return err
 	}
-	defer r.Clean(true, true)
+	defer r.Clean()
 	err = r.SetConfig(g)
 	if err != nil {
 		return err
@@ -271,7 +269,7 @@ func RuntimeOutsideValidate(g *generate.Generator, t *tap.T, f AfterFunc) error 
 		os.RemoveAll(bundleDir)
 		return err
 	}
-	defer r.Clean(true, true)
+	defer r.Clean()
 	err = r.SetConfig(g)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is another follow up to PRs #728 and #732, fixing a few issues introduced by them, with some related cleanups and fixes. Please see individual commits for more details.

In particular, this fixes rootfsPropagation test failure when running the test inside a Docker container), caused by https://github.com/opencontainers/runtime-tools/pull/732/commits/8e1a3b587864ef065f7eff09e54933720d950117 (which adds new capabilities to the list, and those caps are not yet known to Docker daemon used for CI).

Currently a draft which I am about to test in crun repo.