### PR TITLE
Makefile: replace TAP with TAPTOOL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX ?= $(DESTDIR)/usr
 BINDIR ?= $(DESTDIR)/usr/bin
-TAP ?= tap
+TAPTOOL ?= tap
 
 BUILDTAGS=
 RUNTIME ?= runc
@@ -50,7 +50,7 @@ localvalidation:
 			exit 1; \
 		fi; \
 	done
-	RUNTIME=$(RUNTIME) $(TAP) $(VALIDATION_TESTS)
+	RUNTIME=$(RUNTIME) $(TAPTOOL) $(VALIDATION_TESTS)
 
 .PHONY: validation-executables
 validation-executables: $(VALIDATION_TESTS)

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ If you cannot install node-tap, you can probably run the test suite with another
 For example, with [`prove`][prove]:
 
 ```console
-$ sudo make TAP='prove -Q -j9' RUNTIME=runc VALIDATION_TESTS=validation/pidfile/pidfile.t localvalidation
+$ sudo make TAPTOOL='prove -Q -j9' RUNTIME=runc VALIDATION_TESTS=validation/pidfile/pidfile.t localvalidation
 RUNTIME=runc prove -Q -j9 validation/pidfile.t
 All tests successful.
 Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.03 cusr  0.03 csys =  0.08 CPU)


### PR DESCRIPTION
Apparently, TAP is used by node-tap, so when it is used to specify a
path to node-tap, this results in a failure:

	$ make TAP=/path/to/node-tap localvalidation
	...
	Error: Environment variable TAP must be set to 0 or 1 only

Fixes: #723