### PR TITLE
Add syscall "statx" in seccomp to fix Operation not permitted

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -303,6 +303,7 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 				"stat64",
 				"statfs",
 				"statfs64",
+				"statx",
 				"symlink",
 				"symlinkat",
 				"sync",


### PR DESCRIPTION
syscall "statx" was first introduced by kernel at version 4.11, which
is a new implementation of stat, caller can request specific
information(file size only) to speed up the call. Docker has the statx
in seccomp config as well.

Signed-off-by: CooperLi <1866858@gmail.com>