### PR TITLE
Use new golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,13 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/setup-go@v3
         with:
-          version: v1.42
+          go-version: 1.17
+      - uses: actions/checkout@v3
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46.2
 
   commit:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The job `lint` has a lot of errors from typecheck that don't seem valid. The new golangci-lint with the new Go doesn't complain about the existing code.