### PR TITLE
seccomp: Separate conditions for personality syscall into single rule

### DIFF
--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -354,11 +354,23 @@ func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 					Value: 0x0,
 					Op:    rspec.OpEqualTo,
 				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
 				{
 					Index: 0,
 					Value: 0x0008,
 					Op:    rspec.OpEqualTo,
 				},
+			},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
 				{
 					Index: 0,
 					Value: 0xffffffff,


### PR DESCRIPTION
Separate each syscall condition (argument) for personality syscall into
a single rule because the libseccomp can only compare each condition once
in a single rule. Otherwise, the adding returns EINVAL on failure.
In order to address the failure, general OCI runtimes such as runc add each
condition as a separate rule if two or more conditions have the same conditions,
but this is a way for keeping compatibility (old behavior). Hence, it will lead
wrong behavior because the conditions for the rules will be logical-OR instead of
logical-AND.
In case of the OCI tests for personality syscall, we should explicitly separate
the conditions into a single rule as logical-OR for container runtimes that do not
support the above old behavior.

Ref. https://man7.org/linux/man-pages/man3/seccomp_rule_add.3.html

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>