### PR TITLE
generate, validate: isolate gojson* dependencies.

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -10,7 +10,7 @@ import (
 
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate/seccomp"
-	"github.com/opencontainers/runtime-tools/validate"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -1140,7 +1140,7 @@ func (g *Generator) SetupPrivileged(privileged bool) {
 	if privileged { // Add all capabilities in privileged mode.
 		var finalCapList []string
 		for _, cap := range capability.List() {
-			if g.HostSpecific && cap > validate.LastCap() {
+			if g.HostSpecific && cap > capsCheck.LastCap() {
 				continue
 			}
 			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
@@ -1174,7 +1174,7 @@ func (g *Generator) ClearProcessCapabilities() {
 // AddProcessCapability adds a process capability into all 5 capability sets.
 func (g *Generator) AddProcessCapability(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1237,7 +1237,7 @@ func (g *Generator) AddProcessCapability(c string) error {
 // AddProcessCapabilityAmbient adds a process capability into g.Config.Process.Capabilities.Ambient.
 func (g *Generator) AddProcessCapabilityAmbient(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1261,7 +1261,7 @@ func (g *Generator) AddProcessCapabilityAmbient(c string) error {
 // AddProcessCapabilityBounding adds a process capability into g.Config.Process.Capabilities.Bounding.
 func (g *Generator) AddProcessCapabilityBounding(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1284,7 +1284,7 @@ func (g *Generator) AddProcessCapabilityBounding(c string) error {
 // AddProcessCapabilityEffective adds a process capability into g.Config.Process.Capabilities.Effective.
 func (g *Generator) AddProcessCapabilityEffective(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1307,7 +1307,7 @@ func (g *Generator) AddProcessCapabilityEffective(c string) error {
 // AddProcessCapabilityInheritable adds a process capability into g.Config.Process.Capabilities.Inheritable.
 func (g *Generator) AddProcessCapabilityInheritable(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1330,7 +1330,7 @@ func (g *Generator) AddProcessCapabilityInheritable(c string) error {
 // AddProcessCapabilityPermitted adds a process capability into g.Config.Process.Capabilities.Permitted.
 func (g *Generator) AddProcessCapabilityPermitted(c string) error {
 	cp := strings.ToUpper(c)
-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+	if err := capsCheck.CapValid(cp, g.HostSpecific); err != nil {
 		return err
 	}
 
@@ -1383,7 +1383,7 @@ func (g *Generator) DropProcessCapability(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityAmbient drops a process capability from g.Config.Process.Capabilities.Ambient.
@@ -1399,7 +1399,7 @@ func (g *Generator) DropProcessCapabilityAmbient(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityBounding drops a process capability from g.Config.Process.Capabilities.Bounding.
@@ -1415,7 +1415,7 @@ func (g *Generator) DropProcessCapabilityBounding(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityEffective drops a process capability from g.Config.Process.Capabilities.Effective.
@@ -1431,7 +1431,7 @@ func (g *Generator) DropProcessCapabilityEffective(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityInheritable drops a process capability from g.Config.Process.Capabilities.Inheritable.
@@ -1447,7 +1447,7 @@ func (g *Generator) DropProcessCapabilityInheritable(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 // DropProcessCapabilityPermitted drops a process capability from g.Config.Process.Capabilities.Permitted.
@@ -1463,7 +1463,7 @@ func (g *Generator) DropProcessCapabilityPermitted(c string) error {
 		}
 	}
 
-	return validate.CapValid(cp, false)
+	return capsCheck.CapValid(cp, false)
 }
 
 func mapStrToNamespace(ns string, path string) (rspec.LinuxNamespace, error) {

--- a/validate/capabilities/validate.go
+++ b/validate/capabilities/validate.go
@@ -1,0 +1,31 @@
+package capabilities
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/syndtr/gocapability/capability"
+)
+
+// CapValid checks whether a capability is valid
+func CapValid(c string, hostSpecific bool) error {
+	isValid := false
+
+	if !strings.HasPrefix(c, "CAP_") {
+		return fmt.Errorf("capability %s must start with CAP_", c)
+	}
+	for _, cap := range capability.List() {
+		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
+			if hostSpecific && cap > LastCap() {
+				return fmt.Errorf("%s is not supported on the current host", c)
+			}
+			isValid = true
+			break
+		}
+	}
+
+	if !isValid {
+		return fmt.Errorf("invalid capability: %s", c)
+	}
+	return nil
+}

--- a/validate/capabilities/validate_linux.go
+++ b/validate/capabilities/validate_linux.go
@@ -1,0 +1,16 @@
+package capabilities
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	last := capability.CAP_LAST_CAP
+	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
+	if last == capability.Cap(63) {
+		last = capability.CAP_BLOCK_SUSPEND
+	}
+
+	return last
+}

--- a/validate/capabilities/validate_unsupported.go
+++ b/validate/capabilities/validate_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package validate
+
+import (
+	"github.com/syndtr/gocapability/capability"
+)
+
+// LastCap return last cap of system
+func LastCap() capability.Cap {
+	return capability.Cap(-1)
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -20,8 +20,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	osFilepath "github.com/opencontainers/runtime-tools/filepath"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/sirupsen/logrus"
-	"github.com/syndtr/gocapability/capability"
 
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/xeipuuv/gojsonschema"
@@ -687,26 +687,10 @@ func (v *Validator) CheckAnnotations() (errs error) {
 }
 
 // CapValid checks whether a capability is valid
+//
+// Deprecated: use github.com/opencontainers/runtime-tools/validate/capabilities.CapValid directly.
 func CapValid(c string, hostSpecific bool) error {
-	isValid := false
-
-	if !strings.HasPrefix(c, "CAP_") {
-		return fmt.Errorf("capability %s must start with CAP_", c)
-	}
-	for _, cap := range capability.List() {
-		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
-			if hostSpecific && cap > LastCap() {
-				return fmt.Errorf("%s is not supported on the current host", c)
-			}
-			isValid = true
-			break
-		}
-	}
-
-	if !isValid {
-		return fmt.Errorf("invalid capability: %s", c)
-	}
-	return nil
+	return capsCheck.CapValid(c, hostSpecific)
 }
 
 func envValid(env string) bool {

--- a/validate/validate_linux.go
+++ b/validate/validate_linux.go
@@ -11,26 +11,19 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/syndtr/gocapability/capability"
-
 	multierror "github.com/hashicorp/go-multierror"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	osFilepath "github.com/opencontainers/runtime-tools/filepath"
 	"github.com/opencontainers/runtime-tools/specerror"
+	capsCheck "github.com/opencontainers/runtime-tools/validate/capabilities"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 )
 
 // LastCap return last cap of system
-func LastCap() capability.Cap {
-	last := capability.CAP_LAST_CAP
-	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
-	if last == capability.Cap(63) {
-		last = capability.CAP_BLOCK_SUSPEND
-	}
-
-	return last
-}
+//
+// Deprecated: use github.com/opencontainers/runtime-tools/validate/capabilities.LastCap directly.
+var LastCap = capsCheck.LastCap
 
 func deviceValid(d rspec.LinuxDevice) bool {
 	switch d.Type {


### PR DESCRIPTION
Split out those few capability validation functions (`LastCap()`, `CapValid()`) which `Generator` depends on into a `validate/capabilities` subpackage of their own. This should prevent `github.com/xeipuuv/gojson*` from sneaking in to the dependencies of anyone who uses `Generator` for `OCI Spec` manipulation.

Those `gojsonschema` and related packages are often considered problematic because they do not seem to be actively maintained. At the time of this commit they received their last updates in 2018, 2019 and 2020. Excluding them from the dependency blast radius can lower the barrier for accepting/allowing import of generate.Generator. 