### PR TITLE
validate/capabilities: fix incorrect package name.

### DIFF
--- a/validate/capabilities/validate_unsupported.go
+++ b/validate/capabilities/validate_unsupported.go
@@ -1,7 +1,7 @@
 //go:build !linux
 // +build !linux
 
-package validate
+package capabilities
 
 import (
 	"github.com/syndtr/gocapability/capability"


### PR DESCRIPTION
Fix incorrect package name (should be `capabilities` not `validate`) for non-linux builds in validate/capabilities.

Signed-off-by: Krisztian Litkey <krisztian.litkey@intel.com>