### PR TITLE
Revert "Change /dev to be mounted by default with /noexec"

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -182,7 +182,7 @@ func New(os string) (generator Generator, err error) {
 				Destination: "/dev",
 				Type:        "tmpfs",
 				Source:      "tmpfs",
-				Options:     []string{"nosuid", "noexec", "strictatime", "mode=755", "size=65536k"},
+				Options:     []string{"nosuid", "strictatime", "mode=755", "size=65536k"},
 			},
 			{
 				Destination: "/dev/pts",


### PR DESCRIPTION
Closes: #759 

This reverts commit 09d837bf40a7356a478e40642e36f5f7e1dea7d1.

Mounting /dev with 'noexec' option triggers problems when containers try to create Intel SGX enclaves:

...
ioctl(4, SGX_IOC_ENCLAVE_ADD_PAGES, 0x7ffd38e7bf90) = 0 mmap(0x7f36d9002000, 139264, PROT_READ|PROT_EXEC, MAP_SHARED|MAP_FIXED, 4, 0) = -1 EPERM (Operation not permitted) close(4)
...

The issue where a device node is mmap()'d with PROT_EXEC has been discussed in length on Linux development mailing lists and with udev/systemd maintainers [1].

As a result of this conversation, systemd changed its defaults to mount /dev with 'exec' [2] and added ExecPaths= and NoExecPaths= [3] to let users to control the behavior.

Change runtime-tools to follow the systemd default and to get the runtime behavior fixed for Intel SGX based confidential compute.

[1] https://lore.kernel.org/linux-sgx/CALCETrWM2rGPRudtaQ=mn9MRsrbQqFfZDkOGsBbVMsk6mMw_+A@mail.gmail.com/
[2] https://github.com/systemd/systemd/pull/17940
[3] https://github.com/systemd/systemd/issues/17942

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>