### PR TITLE
Remove io/ioutil package references.

### DIFF
--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -3,7 +3,6 @@ package cgroups
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func FindCgroup() (Cgroup, error) {
 
 // GetSubsystemPath gets path of subsystem
 func GetSubsystemPath(pid int, subsystem string) (string, error) {
-	contents, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	contents, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
 	}

--- a/cgroups/cgroups_v1.go
+++ b/cgroups/cgroups_v1.go
@@ -2,7 +2,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -62,7 +61,7 @@ func (cg *CgroupV1) GetBlockIOData(pid int, cgPath string) (*rspec.LinuxBlockIO,
 			}
 			filePath = filepath.Join(cg.MountPath, "blkio", subPath, fileName)
 		}
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, specerror.NewError(specerror.CgroupsPathAttach, fmt.Errorf("The runtime MUST consistently attach to the same place in the cgroups hierarchy given the same value of `cgroupsPath`"), rspec.Version)
@@ -237,7 +236,7 @@ func (cg *CgroupV1) GetCPUData(pid int, cgPath string) (*rspec.LinuxCPU, error) 
 			}
 			filePath = filepath.Join(cg.MountPath, "cpu", subPath, fileName)
 		}
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, specerror.NewError(specerror.CgroupsPathAttach, fmt.Errorf("The runtime MUST consistently attach to the same place in the cgroups hierarchy given the same value of `cgroupsPath`"), rspec.Version)
@@ -271,7 +270,7 @@ func (cg *CgroupV1) GetCPUData(pid int, cgPath string) (*rspec.LinuxCPU, error) 
 	}
 	// CONFIG_RT_GROUP_SCHED may be not set
 	// Can always get rt data from /proc
-	contents, err := ioutil.ReadFile("/proc/sys/kernel/sched_rt_period_us")
+	contents, err := os.ReadFile("/proc/sys/kernel/sched_rt_period_us")
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +279,7 @@ func (cg *CgroupV1) GetCPUData(pid int, cgPath string) (*rspec.LinuxCPU, error) 
 		return nil, err
 	}
 	lc.RealtimePeriod = &rtPeriod
-	contents, err = ioutil.ReadFile("/proc/sys/kernel/sched_rt_runtime_us")
+	contents, err = os.ReadFile("/proc/sys/kernel/sched_rt_runtime_us")
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +303,7 @@ func (cg *CgroupV1) GetCPUData(pid int, cgPath string) (*rspec.LinuxCPU, error) 
 			}
 			filePath = filepath.Join(cg.MountPath, "cpuset", subPath, fileName)
 		}
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, err
 		}
@@ -334,7 +333,7 @@ func (cg *CgroupV1) GetDevicesData(pid int, cgPath string) ([]rspec.LinuxDeviceC
 		}
 		filePath = filepath.Join(cg.MountPath, "devices", subPath, fileName)
 	}
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -403,12 +402,12 @@ func inBytes(size string) (int64, error) {
 // eg. ["64KB", "2MB", "1GB"]
 func GetHugePageSize() ([]string, error) {
 	var pageSizes []string
-	files, err := ioutil.ReadDir("/sys/kernel/mm/hugepages")
+	entries, err := os.ReadDir("/sys/kernel/mm/hugepages")
 	if err != nil {
 		return pageSizes, err
 	}
-	for _, st := range files {
-		nameArray := strings.Split(st.Name(), "-")
+	for _, entry := range entries {
+		nameArray := strings.Split(entry.Name(), "-")
 		pageSize, err := inBytes(nameArray[1])
 		if err != nil {
 			return []string{}, err
@@ -457,7 +456,7 @@ func (cg *CgroupV1) GetHugepageLimitData(pid int, cgPath string) ([]rspec.LinuxH
 			}
 			filePath = filepath.Join(cg.MountPath, "hugetlb", subPath, maxUsage)
 		}
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, specerror.NewError(specerror.CgroupsPathAttach, fmt.Errorf("The runtime MUST consistently attach to the same place in the cgroups hierarchy given the same value of `cgroupsPath`"), rspec.Version)
@@ -504,7 +503,7 @@ func (cg *CgroupV1) GetMemoryData(pid int, cgPath string) (*rspec.LinuxMemory, e
 			}
 			filePath = filepath.Join(cg.MountPath, "memory", subPath, fileName)
 		}
-		contents, err := ioutil.ReadFile(filePath)
+		contents, err := os.ReadFile(filePath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, specerror.NewError(specerror.CgroupsPathAttach, fmt.Errorf("The runtime MUST consistently attach to the same place in the cgroups hierarchy given the same value of `cgroupsPath`"), rspec.Version)
@@ -597,7 +596,7 @@ func (cg *CgroupV1) GetNetworkData(pid int, cgPath string) (*rspec.LinuxNetwork,
 		}
 		filePath = filepath.Join(cg.MountPath, "net_cls", subPath, fileName)
 	}
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, specerror.NewError(specerror.CgroupsPathAttach, fmt.Errorf("The runtime MUST consistently attach to the same place in the cgroups hierarchy given the same value of `cgroupsPath`"), rspec.Version)
@@ -624,7 +623,7 @@ func (cg *CgroupV1) GetNetworkData(pid int, cgPath string) (*rspec.LinuxNetwork,
 		}
 		filePath = filepath.Join(cg.MountPath, "net_prio", subPath, fileName)
 	}
-	contents, err = ioutil.ReadFile(filePath)
+	contents, err = os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +667,7 @@ func (cg *CgroupV1) GetPidsData(pid int, cgPath string) (*rspec.LinuxPids, error
 		}
 		filePath = filepath.Join(cg.MountPath, "pids", subPath, fileName)
 	}
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1,7 +1,6 @@
 package generate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -31,7 +30,7 @@ func TestGenerateValid(t *testing.T) {
 			continue
 		}
 
-		bundle, err := ioutil.TempDir("", "TestGenerateValid_bundle")
+		bundle, err := os.MkdirTemp("", "TestGenerateValid_bundle")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -88,7 +87,7 @@ func NewValidatorFromPath(bundlePath string, hostSpecific bool, platform string)
 	}
 
 	configPath := filepath.Join(bundlePath, specConfig)
-	content, err := ioutil.ReadFile(configPath)
+	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return Validator{}, specerror.NewError(specerror.ConfigInRootBundleDir, err, rspec.Version)
 	}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -2,7 +2,6 @@ package validate
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -263,7 +262,7 @@ func TestJSONSchema(t *testing.T) {
 }
 
 func TestCheckRoot(t *testing.T) {
-	tmpBundle, err := ioutil.TempDir("", "oci-check-rootfspath")
+	tmpBundle, err := os.MkdirTemp("", "oci-check-rootfspath")
 	if err != nil {
 		t.Fatalf("Failed to create a TempDir in 'CheckRoot'")
 	}

--- a/validation/delete_only_create_resources/delete_only_create_resources.go
+++ b/validation/delete_only_create_resources/delete_only_create_resources.go
@@ -2,18 +2,17 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	"github.com/mrunalp/fileutils"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -62,7 +61,7 @@ func main() {
 		util.Fatal(err)
 	}
 	// Add the container to the cgroup
-	err = ioutil.WriteFile(filepath.Join(testPath, "tasks"), []byte(strconv.Itoa(state.Pid)), 0644)
+	err = os.WriteFile(filepath.Join(testPath, "tasks"), []byte(strconv.Itoa(state.Pid)), 0644)
 	if err != nil {
 		util.Fatal(err)
 	}

--- a/validation/hooks/hooks.go
+++ b/validation/hooks/hooks.go
@@ -2,16 +2,16 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	err := util.RuntimeLifecycleValidate(config)
-	outputData, _ := ioutil.ReadFile(output)
+	outputData, _ := os.ReadFile(output)
 	if err == nil && string(outputData) != "pre-start1 called\npre-start2 called\npost-start1\npost-start2\npost-stop1\npost-stop2\n" {
 		err = specerror.NewError(specerror.PosixHooksCalledInOrder, fmt.Errorf("Hooks MUST be called in the listed order"), rspec.Version)
 		diagnostic := map[string]string{

--- a/validation/hooks_stdin/hooks_stdin.go
+++ b/validation/hooks_stdin/hooks_stdin.go
@@ -4,23 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"time"
 
+	"github.com/google/uuid"
 	multierror "github.com/hashicorp/go-multierror"
 	tap "github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func stdinStateCheck(outputDir, hookName string, expectedState rspecs.State) (errs *multierror.Error) {
 	var state rspecs.State
-	data, err := ioutil.ReadFile(filepath.Join(outputDir, hookName))
+	data, err := os.ReadFile(filepath.Join(outputDir, hookName))
 	if err != nil {
 		errs = multierror.Append(errs, err)
 		return

--- a/validation/linux_masked_paths/linux_masked_paths.go
+++ b/validation/linux_masked_paths/linux_masked_paths.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func checkMaskedPaths(t *tap.T) error {
 			return err
 		}
 		// create a temp file to make testDir non-empty
-		tmpfile, err := ioutil.TempFile(testDir, "tmp")
+		tmpfile, err := os.CreateTemp(testDir, "tmp")
 		if err != nil {
 			return err
 		}
@@ -50,17 +49,17 @@ func checkMaskedPaths(t *tap.T) error {
 		// runtimetest cannot check the readability of empty files, so
 		// write something.
 		testSubSubFile := filepath.Join(path, maskedFileSubSub)
-		if err := ioutil.WriteFile(testSubSubFile, []byte("secrets"), 0777); err != nil {
+		if err := os.WriteFile(testSubSubFile, []byte("secrets"), 0777); err != nil {
 			return err
 		}
 
 		testSubFile := filepath.Join(path, maskedFileSub)
-		if err := ioutil.WriteFile(testSubFile, []byte("secrets"), 0777); err != nil {
+		if err := os.WriteFile(testSubFile, []byte("secrets"), 0777); err != nil {
 			return err
 		}
 
 		testFile := filepath.Join(path, maskedFile)
-		return ioutil.WriteFile(testFile, []byte("secrets"), 0777)
+		return os.WriteFile(testFile, []byte("secrets"), 0777)
 	})
 	return err
 }

--- a/validation/linux_readonly_paths/linux_readonly_paths.go
+++ b/validation/linux_readonly_paths/linux_readonly_paths.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func checkReadonlyPaths(t *tap.T) error {
 			return err
 		}
 		// create a temp file to make testDir non-empty
-		tmpfile, err := ioutil.TempFile(testDir, "tmp")
+		tmpfile, err := os.CreateTemp(testDir, "tmp")
 		if err != nil {
 			return err
 		}
@@ -50,17 +49,17 @@ func checkReadonlyPaths(t *tap.T) error {
 		// runtimetest cannot check the readability of empty files, so
 		// write something.
 		testSubSubFile := filepath.Join(path, readonlyFileSubSub)
-		if err := ioutil.WriteFile(testSubSubFile, []byte("immutable"), 0777); err != nil {
+		if err := os.WriteFile(testSubSubFile, []byte("immutable"), 0777); err != nil {
 			return err
 		}
 
 		testSubFile := filepath.Join(path, readonlyFileSub)
-		if err := ioutil.WriteFile(testSubFile, []byte("immutable"), 0777); err != nil {
+		if err := os.WriteFile(testSubFile, []byte("immutable"), 0777); err != nil {
 			return err
 		}
 
 		testFile := filepath.Join(path, readonlyFile)
-		return ioutil.WriteFile(testFile, []byte("immutable"), 0777)
+		return os.WriteFile(testFile, []byte("immutable"), 0777)
 	})
 	return err
 }

--- a/validation/misc_props/misc_props.go
+++ b/validation/misc_props/misc_props.go
@@ -3,16 +3,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func saveConfig(path string, v interface{}) error {
@@ -21,7 +20,7 @@ func saveConfig(path string, v interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0644)
 }
 
 func main() {

--- a/validation/pidfile/pidfile.go
+++ b/validation/pidfile/pidfile.go
@@ -2,23 +2,22 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
 	t := tap.New()
 	t.Header(0)
 
-	tempDir, err := ioutil.TempDir("", "oci-pid")
+	tempDir, err := os.MkdirTemp("", "oci-pid")
 	if err != nil {
 		util.Fatal(err)
 	}
@@ -39,7 +38,7 @@ func main() {
 			return nil
 		},
 		PostCreate: func(r *util.Runtime) error {
-			pidData, err := ioutil.ReadFile(tempPidFile)
+			pidData, err := os.ReadFile(tempPidFile)
 			if err != nil {
 				return err
 			}

--- a/validation/poststart/poststart.go
+++ b/validation/poststart/poststart.go
@@ -2,18 +2,17 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -40,7 +39,7 @@ func main() {
 			return r.SetConfig(g)
 		},
 		PostCreate: func(r *util.Runtime) error {
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err == nil {
 				if strings.Contains(string(outputData), "post-start called") {
 					return specerror.NewError(specerror.PoststartTiming, fmt.Errorf("The post-start hooks MUST be called before the `start` operation returns"), rspec.Version)
@@ -53,7 +52,7 @@ func main() {
 		},
 		PreDelete: func(r *util.Runtime) error {
 			util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second)
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err != nil {
 				return fmt.Errorf("%v\n%v", specerror.NewError(specerror.PoststartHooksInvoke, fmt.Errorf("The poststart hooks MUST be invoked by the runtime"), rspec.Version), specerror.NewError(specerror.ProcImplement, fmt.Errorf("The runtime MUST run the user-specified program, as specified by `process`"), rspec.Version))
 			}

--- a/validation/poststart_fail/poststart_fail.go
+++ b/validation/poststart_fail/poststart_fail.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -57,7 +56,7 @@ func main() {
 	}
 
 	runErr := util.RuntimeLifecycleValidate(config)
-	outputData, _ := ioutil.ReadFile(output)
+	outputData, _ := os.ReadFile(output)
 
 	// if runErr is not nil, it means the runtime generates an error
 	// if outputData is not equal to the expected content, it means there is something wrong with the remaining hooks and lifecycle

--- a/validation/poststop/poststop.go
+++ b/validation/poststop/poststop.go
@@ -3,18 +3,17 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -41,7 +40,7 @@ func main() {
 			return r.SetConfig(g)
 		},
 		PostCreate: func(r *util.Runtime) error {
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err == nil {
 				if strings.Contains(string(outputData), "post-stop called") {
 					return specerror.NewError(specerror.PoststopTiming, fmt.Errorf("The post-stop hooks MUST be called after the container is deleted"), rspec.Version)
@@ -54,7 +53,7 @@ func main() {
 		},
 		PreDelete: func(r *util.Runtime) error {
 			util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second)
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err != nil {
 				return specerror.NewError(specerror.ProcImplement, fmt.Errorf("The runtime MUST run the user-specified program, as specified by `process`"), rspec.Version)
 			}
@@ -70,7 +69,7 @@ func main() {
 			}
 		},
 		PostDelete: func(r *util.Runtime) error {
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err != nil {
 				return fmt.Errorf("%v\n%v", specerror.NewError(specerror.PoststopHooksInvoke, fmt.Errorf("The poststop hooks MUST be invoked by the runtime"), rspec.Version), specerror.NewError(specerror.ProcImplement, fmt.Errorf("The runtime MUST run the user-specified program, as specified by `process`"), rspec.Version))
 			}

--- a/validation/poststop_fail/poststop_fail.go
+++ b/validation/poststop_fail/poststop_fail.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -58,7 +57,7 @@ func main() {
 	}
 
 	runErr := util.RuntimeLifecycleValidate(config)
-	outputData, _ := ioutil.ReadFile(output)
+	outputData, _ := os.ReadFile(output)
 	// if runErr is not nil, it means the runtime generates an error
 	// if outputData is not equal to the expected content, it means there is something wrong with the remaining hooks and lifecycle
 	if runErr != nil || string(outputData) != "post-stop called\n" {

--- a/validation/prestart/prestart.go
+++ b/validation/prestart/prestart.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	tap "github.com/mndrix/tap-go"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -39,7 +39,7 @@ func main() {
 			return r.SetConfig(g)
 		},
 		PostCreate: func(r *util.Runtime) error {
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err == nil {
 				if strings.Contains(string(outputData), "pre-start called") {
 					return specerror.NewError(specerror.PrestartTiming, fmt.Errorf("Pre-start hooks MUST be called after the `start` operation is called"), rspec.Version)
@@ -53,7 +53,7 @@ func main() {
 		},
 		PreDelete: func(r *util.Runtime) error {
 			util.WaitingForStatus(*r, util.LifecycleStatusStopped, time.Second*10, time.Second)
-			outputData, err := ioutil.ReadFile(output)
+			outputData, err := os.ReadFile(output)
 			if err != nil {
 				return fmt.Errorf("%v\n%v", specerror.NewError(specerror.PrestartHooksInvoke, fmt.Errorf("The prestart hooks MUST be invoked by the runtime"), rspec.Version), specerror.NewError(specerror.ProcImplement, fmt.Errorf("The runtime MUST run the user-specified program, as specified by `process`"), rspec.Version))
 			}

--- a/validation/start/start.go
+++ b/validation/start/start.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mndrix/tap-go"
 	rspecs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/specerror"
 	"github.com/opencontainers/runtime-tools/validation/util"
-	"github.com/google/uuid"
 )
 
 func main() {
@@ -72,7 +71,7 @@ func main() {
 			t.Fail(err.Error())
 			return
 		}
-		outputData, outputErr := ioutil.ReadFile(output)
+		outputData, outputErr := os.ReadFile(output)
 		// check the output
 		util.SpecErrorOK(t, outputErr == nil && string(outputData) == "process called\n", specerror.NewError(specerror.StartProcImplement, fmt.Errorf("`start` operation MUST run the user-specified program as specified by `process`"), rspecs.Version), outputErr)
 	}
@@ -88,7 +87,7 @@ func main() {
 		return
 	}
 
-	outputData, outputErr := ioutil.ReadFile(output)
+	outputData, outputErr := os.ReadFile(output)
 	// must have no effect, it will not be something like 'process called\nprocess called\n'
 	util.SpecErrorOK(t, outputErr == nil && string(outputData) == "process called\n", specerror.NewError(specerror.StartNotCreatedHaveNoEffect, fmt.Errorf("attempting to `start` a container that is not `created` MUST have no effect on the container"), rspecs.Version), outputErr)
 

--- a/validation/util/container.go
+++ b/validation/util/container.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -108,8 +107,8 @@ func (r *Runtime) Create() (err error) {
 
 // ReadStandardStreams collects content from the stdout and stderr buffers.
 func (r *Runtime) ReadStandardStreams() (stdout []byte, stderr []byte, err error) {
-	stdout, err = ioutil.ReadFile(r.stdout.Name())
-	stderr, err2 := ioutil.ReadFile(r.stderr.Name())
+	stdout, err = os.ReadFile(r.stdout.Name())
+	stderr, err2 := os.ReadFile(r.stderr.Name())
 	if err == nil && err2 != nil {
 		err = err2
 	}

--- a/validation/util/linux_resources_cpus.go
+++ b/validation/util/linux_resources_cpus.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -68,21 +68,21 @@ func ValidateLinuxResourcesCPU(config *rspec.Spec, t *tap.T, state *rspec.State)
 // ValidateLinuxResourcesCPUEmpty validates Linux.Resources.CPU is set to
 // correct values, when each value are set to the default ones.
 func ValidateLinuxResourcesCPUEmpty(config *rspec.Spec, t *tap.T, state *rspec.State) error {
-	outShares, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.shares"))
+	outShares, err := os.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.shares"))
 	if err != nil {
 		return nil
 	}
 	sh, _ := strconv.Atoi(strings.TrimSpace(string(outShares)))
 	defaultShares := uint64(sh)
 
-	outPeriod, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_period_us"))
+	outPeriod, err := os.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_period_us"))
 	if err != nil {
 		return nil
 	}
 	pe, _ := strconv.Atoi(strings.TrimSpace(string(outPeriod)))
 	defaultPeriod := uint64(pe)
 
-	outQuota, err := ioutil.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_quota_us"))
+	outQuota, err := os.ReadFile(filepath.Join(CPUCgroupPrefix, "cpu.cfs_quota_us"))
 	if err != nil {
 		return nil
 	}

--- a/validation/util/test.go
+++ b/validation/util/test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,7 +121,7 @@ func SpecErrorOK(t *tap.T, expected bool, specErr error, detailedErr error) {
 
 // PrepareBundle creates a test bundle in a temporary directory.
 func PrepareBundle() (string, error) {
-	bundleDir, err := ioutil.TempDir("", "ocitest")
+	bundleDir, err := os.MkdirTemp("", "ocitest")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Package io/ioutil has been marked deprecated in Go 1.16. Updates io/ioutil to os package alternatives.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>