### PR TITLE
Add support for LoongArch64

### DIFF
--- a/completions/bash/oci-runtime-tool
+++ b/completions/bash/oci-runtime-tool
@@ -162,6 +162,7 @@ __oci-runtime-tool_complete_seccomp_arches() {
 		s390x
 		parisc
 		parisc64
+		loong64
 	" -- "$cur" ) )
 }
 

--- a/generate/seccomp/parse_architecture.go
+++ b/generate/seccomp/parse_architecture.go
@@ -46,6 +46,7 @@ func parseArch(arch string) (rspec.Arch, error) {
 		"ppc64le":     rspec.ArchPPC64LE,
 		"s390":        rspec.ArchS390,
 		"s390x":       rspec.ArchS390X,
+		"loong64":     rspec.ArchLOONGARCH64,
 	}
 	a, ok := arches[arch]
 	if !ok {

--- a/generate/seccomp/seccomp_default.go
+++ b/generate/seccomp/seccomp_default.go
@@ -25,6 +25,8 @@ func arches() []rspec.Arch {
 		return []rspec.Arch{rspec.ArchMIPSEL, rspec.ArchMIPSEL64, rspec.ArchMIPSEL64N32}
 	case "s390x":
 		return []rspec.Arch{rspec.ArchS390, rspec.ArchS390X}
+	case "loong64":
+		return []rspec.Arch{rspec.ArchLOONGARCH64}
 	default:
 		return []rspec.Arch{}
 	}


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html