### PR TITLE
Add support for latest Go version 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.21.x, 1.20.x]
         race: ["-race", ""]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.54.1
 
   commit:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # oci-runtime-tool [![Build Status](https://travis-ci.org/opencontainers/runtime-tools.svg?branch=master)](https://travis-ci.org/opencontainers/runtime-tools) [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/runtime-tools)](https://goreportcard.com/report/github.com/opencontainers/runtime-tools)
 
 oci-runtime-tool is a collection of tools for working with the [OCI runtime specification][runtime-spec].
-To build from source code, runtime-tools requires Go 1.19.x or above.
+To build from source code, runtime-tools requires Go 1.20.x or above.
 
 ## Table of Contents
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/runtime-tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
- modify min required version to Go `1.20`
-  CI: update `lint` action: bump Go to `1.21`
-  CI: update `lint` action: bump golangci-lint to `v1.54.1`
