### PR TITLE
update runtime-spec v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b
 	github.com/mrunalp/fileutils v0.5.0
-	github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
+	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/selinux v1.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b h1:Ga1nclDSe8gOw37MV
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
-github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb h1:1xSVPOd7/UA+39/hXEGnBJ13p6JFB0E1EvQFlrRDOXI=
-github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
+github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.9.1 h1:b4VPEF3O5JLZgdTDBmGepaaIbAo0GqoF6EBRq5f/g3Y=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -33,6 +33,34 @@ type Spec struct {
 	ZOS *ZOS `json:"zos,omitempty" platform:"zos"`
 }
 
+// Scheduler represents the scheduling attributes for a process. It is based on
+// the Linux sched_setattr(2) syscall.
+type Scheduler struct {
+	// Policy represents the scheduling policy (e.g., SCHED_FIFO, SCHED_RR, SCHED_OTHER).
+	Policy LinuxSchedulerPolicy `json:"policy"`
+
+	// Nice is the nice value for the process, which affects its priority.
+	Nice int32 `json:"nice,omitempty"`
+
+	// Priority represents the static priority of the process.
+	Priority int32 `json:"priority,omitempty"`
+
+	// Flags is an array of scheduling flags.
+	Flags []LinuxSchedulerFlag `json:"flags,omitempty"`
+
+	// The following ones are used by the DEADLINE scheduler.
+
+	// Runtime is the amount of time in nanoseconds during which the process
+	// is allowed to run in a given period.
+	Runtime uint64 `json:"runtime,omitempty"`
+
+	// Deadline is the absolute deadline for the process to complete its execution.
+	Deadline uint64 `json:"deadline,omitempty"`
+
+	// Period is the length of the period in nanoseconds used for determining the process runtime.
+	Period uint64 `json:"period,omitempty"`
+}
+
 // Process contains information to start a specific application inside the container.
 type Process struct {
 	// Terminal creates an interactive terminal for the container.
@@ -60,8 +88,12 @@ type Process struct {
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
 	// Specify an oom_score_adj for the container.
 	OOMScoreAdj *int `json:"oomScoreAdj,omitempty" platform:"linux"`
+	// Scheduler specifies the scheduling attributes for a process
+	Scheduler *Scheduler `json:"scheduler,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+	// IOPriority contains the I/O priority settings for the cgroup.
+	IOPriority *LinuxIOPriority `json:"ioPriority,omitempty" platform:"linux"`
 }
 
 // LinuxCapabilities specifies the list of allowed capabilities that are kept for a process.
@@ -78,6 +110,22 @@ type LinuxCapabilities struct {
 	// Ambient is the ambient set of capabilities that are kept.
 	Ambient []string `json:"ambient,omitempty" platform:"linux"`
 }
+
+// IOPriority represents I/O priority settings for the container's processes within the process group.
+type LinuxIOPriority struct {
+	Class    IOPriorityClass `json:"class"`
+	Priority int             `json:"priority"`
+}
+
+// IOPriorityClass represents an I/O scheduling class.
+type IOPriorityClass string
+
+// Possible values for IOPriorityClass.
+const (
+	IOPRIO_CLASS_RT   IOPriorityClass = "IOPRIO_CLASS_RT"
+	IOPRIO_CLASS_BE   IOPriorityClass = "IOPRIO_CLASS_BE"
+	IOPRIO_CLASS_IDLE IOPriorityClass = "IOPRIO_CLASS_IDLE"
+)
 
 // Box specifies dimensions of a rectangle. Used for specifying the size of a console.
 type Box struct {
@@ -191,6 +239,8 @@ type Linux struct {
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
 	// Personality contains configuration for the Linux personality syscall
 	Personality *LinuxPersonality `json:"personality,omitempty"`
+	// TimeOffsets specifies the offset for supporting time namespaces.
+	TimeOffsets map[string]LinuxTimeOffset `json:"timeOffsets,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -220,6 +270,8 @@ const (
 	UserNamespace LinuxNamespaceType = "user"
 	// CgroupNamespace for isolating cgroup hierarchies
 	CgroupNamespace LinuxNamespaceType = "cgroup"
+	// TimeNamespace for isolating the clocks
+	TimeNamespace LinuxNamespaceType = "time"
 )
 
 // LinuxIDMapping specifies UID/GID mappings
@@ -232,6 +284,14 @@ type LinuxIDMapping struct {
 	Size uint32 `json:"size"`
 }
 
+// LinuxTimeOffset specifies the offset for Time Namespace
+type LinuxTimeOffset struct {
+	// Secs is the offset of clock (in secs) in the container
+	Secs int64 `json:"secs,omitempty"`
+	// Nanosecs is the additional offset for Secs (in nanosecs)
+	Nanosecs uint32 `json:"nanosecs,omitempty"`
+}
+
 // POSIXRlimit type and restrictions
 type POSIXRlimit struct {
 	// Type of the rlimit to set
@@ -242,12 +302,13 @@ type POSIXRlimit struct {
 	Soft uint64 `json:"soft"`
 }
 
-// LinuxHugepageLimit structure corresponds to limiting kernel hugepages
+// LinuxHugepageLimit structure corresponds to limiting kernel hugepages.
+// Default to reservation limits if supported. Otherwise fallback to page fault limits.
 type LinuxHugepageLimit struct {
-	// Pagesize is the hugepage size
-	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.)
+	// Pagesize is the hugepage size.
+	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.).
 	Pagesize string `json:"pageSize"`
-	// Limit is the limit of "hugepagesize" hugetlb usage
+	// Limit is the limit of "hugepagesize" hugetlb reservations (if supported) or usage.
 	Limit uint64 `json:"limit"`
 }
 
@@ -319,6 +380,10 @@ type LinuxMemory struct {
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Enables hierarchical memory accounting
 	UseHierarchy *bool `json:"useHierarchy,omitempty"`
+	// CheckBeforeUpdate enables checking if a new memory limit is lower
+	// than the current usage during update, and if so, rejecting the new
+	// limit.
+	CheckBeforeUpdate *bool `json:"checkBeforeUpdate,omitempty"`
 }
 
 // LinuxCPU for Linux cgroup 'cpu' resource management
@@ -327,6 +392,9 @@ type LinuxCPU struct {
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
 	Quota *int64 `json:"quota,omitempty"`
+	// CPU hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst in a
+	// given period.
+	Burst *uint64 `json:"burst,omitempty"`
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).
@@ -375,7 +443,7 @@ type LinuxResources struct {
 	Pids *LinuxPids `json:"pids,omitempty"`
 	// BlockIO restriction configuration
 	BlockIO *LinuxBlockIO `json:"blockIO,omitempty"`
-	// Hugetlb limit (in bytes)
+	// Hugetlb limits (in bytes). Default to reservation limits if supported.
 	HugepageLimits []LinuxHugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
 	Network *LinuxNetwork `json:"network,omitempty"`
@@ -645,6 +713,10 @@ const (
 	// LinuxSeccompFlagSpecAllow can be used to disable Speculative Store
 	// Bypass mitigation. (since Linux 4.17)
 	LinuxSeccompFlagSpecAllow LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_SPEC_ALLOW"
+
+	// LinuxSeccompFlagWaitKillableRecv can be used to switch to the wait
+	// killable semantics. (since Linux 5.19)
+	LinuxSeccompFlagWaitKillableRecv LinuxSeccompFlag = "SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV"
 )
 
 // Additional architectures permitted to be used for system calls
@@ -765,3 +837,43 @@ type ZOSDevice struct {
 	// Gid of the device.
 	GID *uint32 `json:"gid,omitempty"`
 }
+
+// LinuxSchedulerPolicy represents different scheduling policies used with the Linux Scheduler
+type LinuxSchedulerPolicy string
+
+const (
+	// SchedOther is the default scheduling policy
+	SchedOther LinuxSchedulerPolicy = "SCHED_OTHER"
+	// SchedFIFO is the First-In-First-Out scheduling policy
+	SchedFIFO LinuxSchedulerPolicy = "SCHED_FIFO"
+	// SchedRR is the Round-Robin scheduling policy
+	SchedRR LinuxSchedulerPolicy = "SCHED_RR"
+	// SchedBatch is the Batch scheduling policy
+	SchedBatch LinuxSchedulerPolicy = "SCHED_BATCH"
+	// SchedISO is the Isolation scheduling policy
+	SchedISO LinuxSchedulerPolicy = "SCHED_ISO"
+	// SchedIdle is the Idle scheduling policy
+	SchedIdle LinuxSchedulerPolicy = "SCHED_IDLE"
+	// SchedDeadline is the Deadline scheduling policy
+	SchedDeadline LinuxSchedulerPolicy = "SCHED_DEADLINE"
+)
+
+// LinuxSchedulerFlag represents the flags used by the Linux Scheduler.
+type LinuxSchedulerFlag string
+
+const (
+	// SchedFlagResetOnFork represents the reset on fork scheduling flag
+	SchedFlagResetOnFork LinuxSchedulerFlag = "SCHED_FLAG_RESET_ON_FORK"
+	// SchedFlagReclaim represents the reclaim scheduling flag
+	SchedFlagReclaim LinuxSchedulerFlag = "SCHED_FLAG_RECLAIM"
+	// SchedFlagDLOverrun represents the deadline overrun scheduling flag
+	SchedFlagDLOverrun LinuxSchedulerFlag = "SCHED_FLAG_DL_OVERRUN"
+	// SchedFlagKeepPolicy represents the keep policy scheduling flag
+	SchedFlagKeepPolicy LinuxSchedulerFlag = "SCHED_FLAG_KEEP_POLICY"
+	// SchedFlagKeepParams represents the keep parameters scheduling flag
+	SchedFlagKeepParams LinuxSchedulerFlag = "SCHED_FLAG_KEEP_PARAMS"
+	// SchedFlagUtilClampMin represents the utilization clamp minimum scheduling flag
+	SchedFlagUtilClampMin LinuxSchedulerFlag = "SCHED_FLAG_UTIL_CLAMP_MIN"
+	// SchedFlagUtilClampMin represents the utilization clamp maximum scheduling flag
+	SchedFlagUtilClampMax LinuxSchedulerFlag = "SCHED_FLAG_UTIL_CLAMP_MAX"
+)

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
+	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 2
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/mndrix/tap-go
 # github.com/mrunalp/fileutils v0.5.0
 ## explicit; go 1.13
 github.com/mrunalp/fileutils
-# github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb
+# github.com/opencontainers/runtime-spec v1.1.0
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
 # github.com/opencontainers/selinux v1.9.1


### PR DESCRIPTION
- [x] depends on https://github.com/opencontainers/runtime-tools/pull/773

Update some dependencies to released versions;

### go.mod: github.com/opencontainers/runtime-spec v1.1.0

full diff: https://github.com/opencontainers/runtime-spec/compare/86290f6a00fb...v1.1.0