### PR TITLE
Add Go 1.22 and 1.23, rm old versions, bump CI actions, bump golangci-linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,15 @@ on:
 jobs:
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
-      - uses: actions/checkout@v3
-      - uses: golangci/golangci-lint-action@v3
+          go-version: 1.x # latest
+      - uses: actions/checkout@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.51.2
+          version: v1.61
 
   commit:
     runs-on: ubuntu-22.04
@@ -44,14 +44,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.22.x, 1.23.x]
         race: ["-race", ""]
 
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: install go ${{ matrix.go-version }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: build

--- a/cmd/oci-runtime-tool/main.go
+++ b/cmd/oci-runtime-tool/main.go
@@ -56,7 +56,7 @@ func before(context *cli.Context) error {
 	logLevelString := context.GlobalString("log-level")
 	logLevel, err := logrus.ParseLevel(logLevelString)
 	if err != nil {
-		logrus.Fatalf(err.Error())
+		logrus.Fatal(err)
 	}
 	logrus.SetLevel(logLevel)
 


### PR DESCRIPTION
Mostly a CI refresh. See commits for details.

Closes: #769