### PR TITLE
[RFC] cmd/oci-runtime-tool: new flags for linux.intelRdt

### DIFF
--- a/cmd/oci-runtime-tool/generate.go
+++ b/cmd/oci-runtime-tool/generate.go
@@ -55,6 +55,8 @@ var generateFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "linux-hugepage-limits-add", Usage: "add hugepage resource limits"},
 	cli.StringSliceFlag{Name: "linux-hugepage-limits-drop", Usage: "drop hugepage resource limits"},
 	cli.StringFlag{Name: "linux-intelRdt-closid", Usage: "RDT Class of Service, i.e. group under the resctrl pseudo-filesystem which to associate the container with"},
+	cli.BoolFlag{Name: "linux-intelRdt-enableMonitoring", Usage: "Enable resctrl monitoring for the container"},
+	cli.StringSliceFlag{Name: "linux-intelRdt-schema", Usage: "Specifies the resctrl schema. May be specified multiple times to set multiple schemata."},
 	cli.StringFlag{Name: "linux-intelRdt-l3CacheSchema", Usage: "specifies the schema for L3 cache id and capacity bitmask"},
 	cli.StringSliceFlag{Name: "linux-masked-paths", Usage: "specifies paths can not be read inside container"},
 	cli.Uint64Flag{Name: "linux-mem-kernel-limit", Usage: "kernel memory limit (in bytes)"},
@@ -748,6 +750,12 @@ func setupSpec(g *generate.Generator, context *cli.Context) error {
 
 	if context.IsSet("linux-intelRdt-closid") {
 		g.SetLinuxIntelRdtClosID(context.String("linux-intelRdt-closid"))
+	}
+	if context.IsSet("linux-intelRdt-enableMonitoring") {
+		g.SetLinuxIntelRdtEnableMonitoring(context.Bool("linux-intelRdt-enableMonitoring"))
+	}
+	if context.IsSet("linux-intelRdt-schema") {
+		g.SetLinuxIntelRdtSchemata(context.StringSlice("linux-intelRdt-schema"))
 	}
 
 	if context.IsSet("linux-intelRdt-l3CacheSchema") {

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -201,6 +201,13 @@ read the configuration from `config.json`.
   RDT Class of Service, i.e. group under the resctrl pseudo-filesystem, which
   to associate the container with.
 
+**--linux-intelRdt-enableMonitoring**=""
+  Enable resctrl monitoring for the container.
+
+**--linux-intelRdt-schema**=[]
+  Specifies one resctrl schema. May be specified multiple times to configure the complete schemata.
+  e.g. --linux-intelRdt-schemata="MB:0=80" --linux-intelRdt-schemata="L3:0=ff"
+
 **--linux-intelRdt-l3CacheSchema**=""
   Specifies the schema for L3 cache id and capacity bitmask.
 


### PR DESCRIPTION
Introduce `--linux-intelRdt-schema` and `--linux-intelRdt-enableMonitoring` flags for the oci-runtime-tool generate.

Depends on #788 