### PR TITLE
Makefile: Add build mode pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILDTAGS=
 RUNTIME ?= runc
 COMMIT ?= $(shell git describe --dirty --long --always --tags 2> /dev/null)
 VERSION := ${shell cat ./VERSION}
-BUILD_FLAGS := -tags "$(BUILDTAGS)" -ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)" $(EXTRA_FLAGS)
+BUILD_FLAGS := -tags "$(BUILDTAGS)" -ldflags "-X main.gitCommit=$(COMMIT) -X main.version=$(VERSION) -buildmode=pie" $(EXTRA_FLAGS)
 STATIC_BUILD_FLAGS := -tags "$(BUILDTAGS) netgo osusergo" -ldflags "-extldflags -static -X main.gitCommit=$(COMMIT) -X main.version=$(VERSION)" $(EXTRA_FLAGS)
 VALIDATION_TESTS ?= $(patsubst %.go,%.t,$(shell find ./validation/ -name *.go | grep -v util))
 


### PR DESCRIPTION
When using the lld linker, compilation with PIC is required. The bfd linker may allow it, but the lld linker requires recompilation with -fPIC if relocation is found in PIE.

```
aarch64-poky-linux-ld.lld: error: relocation R_AARCH64_ABS64 cannot be used against symbol 'type:.eq.os.file'; recompile with -fPIC
>>> defined in /tmp/go-link-1382269313/go.o
>>> referenced by go.go
>>>               /tmp/go-link-1382269313/go.o:(.rodata+0x1750)
```