### PR TITLE
generate: add linux net device injection/removal.

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -130,6 +130,13 @@ func (g *Generator) initConfigLinuxResourcesUnified() {
 	}
 }
 
+func (g *Generator) initConfigLinuxNetDevices() {
+	g.initConfigLinux()
+	if g.Config.Linux.NetDevices == nil {
+		g.Config.Linux.NetDevices = map[string]rspec.LinuxNetDevice{}
+	}
+}
+
 func (g *Generator) initConfigSolaris() {
 	g.initConfig()
 	if g.Config.Solaris == nil {

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1660,6 +1660,31 @@ func (g *Generator) AddLinuxReadonlyPaths(path string) {
 	g.Config.Linux.ReadonlyPaths = append(g.Config.Linux.ReadonlyPaths, path)
 }
 
+// AddLinuxNetDevice adds a network device into g.Config.Linux.NetDevices.
+func (g *Generator) AddLinuxNetDevice(hostIf string, netDev *rspec.LinuxNetDevice) {
+	g.initConfigLinuxNetDevices()
+	g.Config.Linux.NetDevices[hostIf] = *netDev
+}
+
+// RemoveLinuxNetDeviceByHostName removes any linux network device with a
+// matching host interface name from g.Config.Linux.NetDevices.
+func (g *Generator) RemoveLinuxNetDeviceByHostName(hostIf string) {
+	g.initConfigLinuxNetDevices()
+	delete(g.Config.Linux.NetDevices, hostIf)
+}
+
+// RemoveLinuxNetDeviceByName removes any linux network device with a
+// matching name from g.Config.Linux.NetDevices.
+func (g *Generator) RemoveLinuxNetDeviceByName(name string) {
+	g.initConfigLinuxNetDevices()
+	for hif, dev := range g.Config.Linux.NetDevices {
+		if dev.Name == name {
+			delete(g.Config.Linux.NetDevices, hif)
+			return
+		}
+	}
+}
+
 func addOrReplaceBlockIOThrottleDevice(tmpList []rspec.LinuxThrottleDevice, major int64, minor int64, rate uint64) []rspec.LinuxThrottleDevice {
 	throttleDevices := tmpList
 	for i, throttleDevice := range throttleDevices {

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	rfc2119 "github.com/opencontainers/runtime-tools/error"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/runtime-tools/specerror"
@@ -154,4 +155,34 @@ func TestMultipleEnvCaching(t *testing.T) {
 	}
 	g.AddMultipleProcessEnv([]string{})
 	assert.Equal(t, []string(nil), g.Config.Process.Env)
+}
+
+func TestAddLinuxNetDevice(t *testing.T) {
+	// Start with empty ENV and add a few
+	g, err := generate.New("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := map[string]rspec.LinuxNetDevice{
+		"eth0": {
+			Name: "eno1",
+		},
+		"eth1": {
+			Name: "eno2",
+		},
+		"eth2": {
+			Name: "eno3",
+		},
+	}
+	g.AddLinuxNetDevice("eth0", &rspec.LinuxNetDevice{Name: "eno1"})
+	g.AddLinuxNetDevice("eth1", &rspec.LinuxNetDevice{Name: "eno2"})
+	g.AddLinuxNetDevice("eth2", &rspec.LinuxNetDevice{Name: "eno3"})
+	assert.Equal(t, expected, g.Config.Linux.NetDevices)
+
+	g.RemoveLinuxNetDeviceByHostName("eth0")
+	delete(expected, "eth0")
+	assert.Equal(t, expected, g.Config.Linux.NetDevices)
+	g.RemoveLinuxNetDeviceByName("eno2")
+	delete(expected, "eth1")
+	assert.Equal(t, expected, g.Config.Linux.NetDevices)
 }


### PR DESCRIPTION
Add `AddLinuxNetDevice()`, `RemoveLinuxNetDeviceByHostName()`, and `RemoveLinuxNetDeviceByName()` for injecting and removing linux network devices to and from the OCI Spec.