### PR TITLE
Add support for the new FreeBSD section in the runtime config.

### DIFF
--- a/generate/config.go
+++ b/generate/config.go
@@ -199,3 +199,24 @@ func (g *Generator) initConfigVM() {
 		g.Config.VM = &rspec.VM{}
 	}
 }
+
+func (g *Generator) initConfigFreeBSD() {
+	g.initConfig()
+	if g.Config.FreeBSD == nil {
+		g.Config.FreeBSD = &rspec.FreeBSD{}
+	}
+}
+
+func (g *Generator) initConfigFreeBSDJail() {
+	g.initConfigFreeBSD()
+	if g.Config.FreeBSD.Jail == nil {
+		g.Config.FreeBSD.Jail = &rspec.FreeBSDJail{}
+	}
+}
+
+func (g *Generator) initConfigFreeBSDJailAllow() {
+	g.initConfigFreeBSDJail()
+	if g.Config.FreeBSD.Jail.Allow == nil {
+		g.Config.FreeBSD.Jail.Allow = &rspec.FreeBSDJailAllow{}
+	}
+}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -260,6 +260,7 @@ func New(os string) (generator Generator, err error) {
 				Options:     []string{},
 			},
 		}
+		config.FreeBSD = &rspec.FreeBSD{}
 	}
 
 	envCache := map[string]int{}
@@ -1886,4 +1887,147 @@ func (g *Generator) SetWindowsResourcesStorage(storage rspec.WindowsStorageResou
 func (g *Generator) SetWindowsServicing(servicing bool) {
 	g.initConfigWindows()
 	g.Config.Windows.Servicing = servicing
+}
+
+// AddFreeBSDDevice - add a device into g.Config.FreeBSD.Devices
+func (g *Generator) AddFreeBSDDevice(device rspec.FreeBSDDevice) {
+	g.initConfigFreeBSD()
+
+	for i, dev := range g.Config.FreeBSD.Devices {
+		if dev.Path == device.Path {
+			g.Config.FreeBSD.Devices[i] = device
+			return
+		}
+	}
+
+	g.Config.FreeBSD.Devices = append(g.Config.FreeBSD.Devices, device)
+}
+
+// RemoveFreeBSDDevice remove a device from g.Config.Linux.Devices
+func (g *Generator) RemoveFreeBSDDevice(path string) {
+	if g.Config == nil || g.Config.FreeBSD == nil || g.Config.FreeBSD.Devices == nil {
+		return
+	}
+
+	for i, device := range g.Config.FreeBSD.Devices {
+		if device.Path == path {
+			g.Config.FreeBSD.Devices = append(g.Config.FreeBSD.Devices[:i], g.Config.FreeBSD.Devices[i+1:]...)
+			return
+		}
+	}
+}
+
+func (g *Generator) SetFreeBSDJailParent(id string) error {
+	g.initConfigFreeBSDJail()
+	p := g.Config.FreeBSD.Jail.Parent
+	if p != "" && p != id {
+		return fmt.Errorf("Jail parent is already set to %s", p)
+	}
+	g.Config.FreeBSD.Jail.Parent = id
+	return nil
+}
+
+func (g *Generator) SetFreeBSDJailHost(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Host = val
+}
+
+func (g *Generator) SetFreeBSDJailIP4(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Ip4 = val
+}
+
+func (g *Generator) SetFreeBSDJailIP4Addr(val []string) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Ip4Addr = val
+}
+
+func (g *Generator) SetFreeBSDJailIP6(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Ip6 = val
+}
+
+func (g *Generator) SetFreeBSDJailIP6Addr(val []string) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Ip6Addr = val
+}
+
+func (g *Generator) SetFreeBSDJailVnet(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Vnet = val
+}
+
+func (g *Generator) SetFreeBSDJailInterface(val string) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.Interface = val
+}
+
+func (g *Generator) SetFreeBSDJailVnetInterfaces(val []string) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.VnetInterfaces = val
+}
+
+func (g *Generator) SetFreeBSDJailSysVMsg(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.SysVMsg = val
+}
+
+func (g *Generator) SetFreeBSDJailSysVSem(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.SysVSem = val
+}
+
+func (g *Generator) SetFreeBSDJailSysVShm(val rspec.FreeBSDSharing) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.SysVShm = val
+}
+
+func (g *Generator) SetFreeBSDJailEnforceStatfs(val int) {
+	g.initConfigFreeBSDJail()
+	g.Config.FreeBSD.Jail.EnforceStatfs = &val
+}
+
+func (g *Generator) SetFreeBSDJailAllowSetHostname(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.SetHostname = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowRawSockets(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.RawSockets = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowChflags(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.Chflags = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowQuotas(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.Quotas = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowSocketAf(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.SocketAf = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowMlock(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.Mlock = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowReservedPorts(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.ReservedPorts = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowSuser(val bool) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.Suser = val
+}
+
+func (g *Generator) SetFreeBSDJailAllowMount(val []string) {
+	g.initConfigFreeBSDJailAllow()
+	g.Config.FreeBSD.Jail.Allow.Mount = val
 }

--- a/man/oci-runtime-tool-generate.1.md
+++ b/man/oci-runtime-tool-generate.1.md
@@ -39,6 +39,108 @@ read the configuration from `config.json`.
   When specified multiple times, files are loaded in order with duplicate
   keys overwriting previous ones.
 
+**--freebsd-device-add**=*PATH:MODE*
+  Add a device file in container. e.g. --freebsd-device-add=/dev/cuau0c/fuse:438
+    *PATH* is the device path.
+    *MODE* is the file mode of the device file.
+  This option can be specified multiple times.
+
+**--freebsd-device-remove**=*PATH*
+  Remove a device file in container.
+  This option can be specified multiple times.
+
+**--freebsd-jail-allow-chflags**
+  Allow using the *chroot* syscall inside the container.
+
+**--freebsd-jail-allow-mlock**
+  Allow using the *mlock* and *munlock* syscalls inside the container.
+
+**--freebsd-jail-allow-mount**=*FSTYPE*
+  Allow mounting filesystems of type *FSTYPE* inside the container.
+  This option can be specified multiple times.
+
+**--freebsd-jail-allow-quotas**
+  Allow administering quotas inside the container.
+
+**--freebsd-jail-allow-raw-sockets**
+  Allow using raw sockets inside the container.
+
+**--freebsd-jail-allow-reserved-ports**
+  Allow using reserved IP ports inside the container.
+
+**--freebsd-jail-allow-set-hostname**
+  Allow setting hostname inside the container.
+
+**--freebsd-jail-allow-socket-af**
+  Allow using non-IP network protocols inside the container.
+
+**--freebsd-jail-allow-suser**
+  Allow super-user inside the container.
+
+**--freebsd-jail-enforce-statfs**=*VALUE*
+  Specifies the visibility of mounts in the container. The value should be one of:
+    *0* all mount points on the host are visible.
+    *1* only mount points below the container's root are visible.
+    *2* syscalls are limited to operate only on a mount-point where the container's root directory is located.
+
+**--freebsd-jail-host**=*SHARING*
+  Specify the jail's host namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the namespace from the host (or parent jail if specified).
+
+**--freebsd-jail-interface**=*INTERFACE*
+  Specifies a network interface to use for IPv4 and IPv6 addresses when not using *VNET*.
+
+**--freebsd-jail-ip4**=*SHARING*
+  Specify the jail's IPv4 namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+    *disable* to stop the container from using IPv4.
+
+**--freebsd-jail-ip4-addr**=*ADDRESS*
+  Specifies an IPv4 address that is available for the container.
+  This option can be specified multiple times.
+
+**--freebsd-jail-ip6**=*SHARING*
+  Specify the jail's IPv6 namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+    *disable* to stop the container from using IPv6.
+
+**--freebsd-jail-ip6-addr**=*ADDRESS*
+  Specifies an IPv6 address that is available for the container.
+  This option can be specified multiple times.
+
+**--freebsd-jail-parent**=*NAME*
+  Specify the name of a parent jail for this container, if required.
+
+**--freebsd-jail-sysvmsg**=*SHARING*
+  Specify the jail's SYSV IPC message namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+    *disable* to stop the container from using SYSV messages.
+
+**--freebsd-jail-sysvsem**=*SHARING*
+  Specify the jail's SYSV IPC semaphore namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+    *disable* to stop the container from using SYSV semaphores.
+
+**--freebsd-jail-sysvshm**=*SHARING*
+  Specify the jail's SYSV IPC shared memory namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+    *disable* to stop the container from using SYSV shared memory.
+
+**--freebsd-jail-vnet**=*SHARING*
+  Specify the jail's VNET namespace. The value of *SHARING* should be one of:
+    *new* to create a new namespace for the container.
+    *inherit* to share the host namespace from the host (or parent jail if specified).
+  
+**--freebsd-jail-vnet-interface**=*INTERFACE*
+  Specifies an interface to move into the container's vnet during its lifetime.
+  This option can be specified multiple times.
+  
 **--help**
   Print usage statement
 


### PR DESCRIPTION
The runtime-spec v1.3.0 release adds support for jail-based FreeBSD containers. This pull request adds support for these new fields in `generate` and `oci-runtime-tool`.