### PR TITLE
ci: update golangci-lint for compatibility with go1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           go-version: stable
       - uses: actions/checkout@v5
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.9
 
   commit:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
ci started failing:

    run golangci-lint
      Running [/home/runner/golangci-lint-2.6.2-linux-amd64/golangci-lint config path] in [/home/runner/work/runtime-tools/runtime-tools] ...
      Running [/home/runner/golangci-lint-2.6.2-linux-amd64/golangci-lint config verify] in [/home/runner/work/runtime-tools/runtime-tools] ...
      Running [/home/runner/golangci-lint-2.6.2-linux-amd64/golangci-lint run] in [/home/runner/work/runtime-tools/runtime-tools] ...
      panic: file requires newer Go version go1.26 (application built with go1.25) [recovered, repanicked]