### PR TITLE
fix: correct lookup for environment variables in cache

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -322,6 +322,7 @@ func NewFromTemplate(r io.Reader) (Generator, error) {
 func createEnvCacheMap(env []string) map[string]int {
 	envMap := make(map[string]int, len(env))
 	for i, val := range env {
+		val, _, _ = strings.Cut(val, "=")
 		envMap[val] = i
 	}
 	return envMap

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -155,3 +155,41 @@ func TestMultipleEnvCaching(t *testing.T) {
 	g.AddMultipleProcessEnv([]string{})
 	assert.Equal(t, []string(nil), g.Config.Process.Env)
 }
+
+func TestEnvCachingOverrides(t *testing.T) {
+	// Test overriding default ENV variables to verify createEnvCacheMap correctly extracts keys
+	g, err := generate.New("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Override existing default ENVs
+	g.AddProcessEnv("TERM", "vt100")
+	g.AddProcessEnv("PATH", "/minimal/path")
+	g.AddProcessEnv("FOO", "bar")
+
+	expected := []string{
+		"PATH=/minimal/path",
+		"TERM=vt100",
+		"FOO=bar",
+	}
+	assert.Equal(t, expected, g.Config.Process.Env)
+
+	// Test AddMultipleProcessEnv with overrides
+	g, err = generate.New("linux")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g.AddMultipleProcessEnv([]string{
+		"TERM=tmux-256color",
+		"NEW_VAR=123",
+	})
+
+	expectedMultiple := []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"TERM=tmux-256color",
+		"NEW_VAR=123",
+	}
+	assert.Equal(t, expectedMultiple, g.Config.Process.Env)
+}


### PR DESCRIPTION
The current implementation keys the environment cache by the full "NAME=VALUE" string. This causes the generator to treat updates to existing variables as new entries, leading to duplicate environment variables in the final configuration.

This change switches the cache key to use only the variable name, ensuring that `AddProcessEnv` correctly updates existing values instead of appending them.

FIXES: #798 
Signed-off-by: Skywalkr-dev <snaveenbharath2005@gmail.com>